### PR TITLE
Check for no certificates and error

### DIFF
--- a/cmd/scepclient/scepclient.go
+++ b/cmd/scepclient/scepclient.go
@@ -87,6 +87,9 @@ func run(cfg runCfg) error {
 			if err != nil {
 				return err
 			}
+			if len(certs) < 1 {
+				return fmt.Errorf("no certificates returned")
+			}
 		} else {
 			certs, err = x509.ParseCertificates(resp)
 			if err != nil {


### PR DESCRIPTION
Guard against no certificates being provided (or possibly incorrectly parsed) in the PKCS7 degenerate from SCEP GetCACert message.