### PR TITLE
add CA Database, switch serial file to text, add CA-Private Key parameter

### DIFF
--- a/cmd/scepserver/scepserver.go
+++ b/cmd/scepserver/scepserver.go
@@ -46,6 +46,7 @@ func main() {
 		flVersion           = flag.Bool("version", false, "prints version information")
 		flPort              = flag.String("port", envString("SCEP_HTTP_LISTEN_PORT", "8080"), "port to listen on")
 		flDepotPath         = flag.String("depot", envString("SCEP_FILE_DEPOT", "depot"), "path to ca folder")
+        //  TODO : how to submit non string passwords?
 		flCAPass            = flag.String("capass", envString("SCEP_CA_PASS", ""), "passwd for the ca.key")
 		flClDuration        = flag.String("crtvalid", envString("SCEP_CERT_VALID", "365"), "validity for new client certificates in days")
 		flChallengePassword = flag.String("challenge", envString("SCEP_CHALLENGE_PASSWORD", ""), "enforce a challenge password")

--- a/cmd/scepserver/scepserver.go
+++ b/cmd/scepserver/scepserver.go
@@ -95,7 +95,7 @@ func main() {
 		svcOptions := []scepserver.ServiceOption{
 			scepserver.ChallengePassword(*flChallengePassword),
 			scepserver.CAKeyPassword([]byte(*flCAPass)),
-		    scepserver.ClientValidity(clientValidity),
+			scepserver.ClientValidity(clientValidity),
 		}
 		svc, err = scepserver.NewService(depot, svcOptions...)
 		if err != nil {

--- a/cmd/scepserver/scepserver.go
+++ b/cmd/scepserver/scepserver.go
@@ -10,6 +10,7 @@ import (
 	"encoding/asn1"
 	"encoding/pem"
 	"errors"
+    "strconv"
 	"flag"
 	"fmt"
 	"math/big"
@@ -46,6 +47,8 @@ func main() {
 		flVersion           = flag.Bool("version", false, "prints version information")
 		flPort              = flag.String("port", envString("SCEP_HTTP_LISTEN_PORT", "8080"), "port to listen on")
 		flDepotPath         = flag.String("depot", envString("SCEP_FILE_DEPOT", "depot"), "path to ca folder")
+		flCAPass            = flag.String("capass", envString("SCEP_CA_PASS", ""), "passwd for the ca.key")
+		flClDuration        = flag.String("crtvalid", envString("SCEP_CERT_VALID", "365"), "validity for new client certificates in days")
 		flChallengePassword = flag.String("challenge", envString("SCEP_CHALLENGE_PASSWORD", ""), "enforce a challenge password")
 	)
 	flag.Usage = func() {
@@ -83,10 +86,17 @@ func main() {
 		}
 	}
 
+    clientValidity, err := strconv.Atoi(*flClDuration)
+    if err != nil {
+			logger.Log("No valid number for client cert validity : ", err)
+			os.Exit(1)
+    }
 	var svc scepserver.Service // scep service
 	{
 		svcOptions := []scepserver.ServiceOption{
 			scepserver.ChallengePassword(*flChallengePassword),
+			scepserver.CAKeyPassword([]byte(*flCAPass)),
+		    scepserver.ClientValidity(clientValidity),
 		}
 		svc, err = scepserver.NewService(depot, svcOptions...)
 		if err != nil {

--- a/server/depot.go
+++ b/server/depot.go
@@ -145,8 +145,7 @@ func (d fileDepot) writeDB(cn string, serial *big.Int, filename string, cert *x5
 
 	file, err := os.OpenFile(name, os.O_CREATE | os.O_RDWR | os.O_APPEND, dbPerm)
 	if err != nil {
-		fmt.Errorf("could not append to "+name+" : %q\n", err.Error())
-		return err
+		return fmt.Errorf("could not append to "+name+" : %q\n", err.Error())
 	}
 	defer file.Close()
 

--- a/server/depot.go
+++ b/server/depot.go
@@ -118,16 +118,15 @@ func (d fileDepot) Serial() (*big.Int, error) {
 	}
 	defer file.Close()
 	r := bufio.NewReader(file)
-	// is there a better way??
 	data, err := r.ReadString('\r')
-	data = strings.TrimSuffix(data ,"\r")
-	data = strings.TrimSuffix(data ,"\n")
 	if err != nil && err != io.EOF {
 		return nil, err
 	}
-	serial, success := s.SetString(data,16)
-	if success != true  {
-		return nil, errors.New("Could not convert "+string(data)+" to serial number")
+	data = strings.TrimSuffix(data ,"\r")
+	data = strings.TrimSuffix(data ,"\n")
+	serial, ok := s.SetString(data,16)
+	if !ok {
+		return nil, errors.New("could not convert "+string(data)+" to serial number")
 	}
 	return serial, nil
 }
@@ -146,7 +145,7 @@ func (d fileDepot) writeDB(cn string, serial *big.Int, filename string, cert *x5
 
 	file, err := os.OpenFile(name, os.O_CREATE | os.O_RDWR | os.O_APPEND, dbPerm)
 	if err != nil {
-		fmt.Printf("Could not append to "+name+" : %q\n", err.Error())
+		fmt.Errorf("could not append to "+name+" : %q\n", err.Error())
 		return err
 	}
 	defer file.Close()
@@ -192,7 +191,6 @@ func (d fileDepot) writeDB(cn string, serial *big.Int, filename string, cert *x5
 	dbEntry.WriteString("\n")
 
 	if _, err := file.Write(dbEntry.Bytes()); err != nil {
-		file.Close()
 		return err
 	}
 	return nil

--- a/server/service.go
+++ b/server/service.go
@@ -163,7 +163,7 @@ func CAKeyPassword(pw []byte) ServiceOption {
 	}
 }
 
-// optional argument to set the validity of signed client certs in days
+// ClientValidity sets the validity of signed client certs in days (optional parameter)
 func ClientValidity(duration int) ServiceOption {
 	return func(s *service) error {
 		s.clientValidity = duration


### PR DESCRIPTION
The patch allows us to :

* generate a CA outside of micromdm
 * this allows us to use openssl directly creating the CA
 * this allows us to use all the nasty OpenSSL features (such as extensions/crls/oscp etc :)
* add the functionality to pass the CA private key password on startup of the server
* add the funcitonality to keep track of all issued certificates in the CA Database (see http://pki-tutorial.readthedocs.io/en/latest/cadb.html)
 * This allows us to revoke certificates later
* switch the serial file format from binary to text