### PR TITLE
Go 1.7 brings context into a core package, and go-kit now requires it…

### DIFF
--- a/client/scep.go
+++ b/client/scep.go
@@ -9,7 +9,7 @@ import (
 	"github.com/go-kit/kit/endpoint"
 	httptransport "github.com/go-kit/kit/transport/http"
 	"github.com/micromdm/scep/server"
-	"golang.org/x/net/context"
+	"context"
 )
 
 // Client implements the SCEP service and extra methods

--- a/cmd/scepclient/scepclient.go
+++ b/cmd/scepclient/scepclient.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"github.com/micromdm/scep/client"
 	"github.com/micromdm/scep/scep"
-	"golang.org/x/net/context"
+	"context"
 	"io/ioutil"
 	"net/url"
 	"os"

--- a/cmd/scepserver/scepserver.go
+++ b/cmd/scepserver/scepserver.go
@@ -24,7 +24,7 @@ import (
 	"github.com/micromdm/scep/depot"
 	"github.com/micromdm/scep/depot/file"
 	"github.com/micromdm/scep/server"
-	"golang.org/x/net/context"
+	"context"
 )
 
 // version info

--- a/server/service.go
+++ b/server/service.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/micromdm/scep/depot"
 	"github.com/micromdm/scep/scep"
-	"golang.org/x/net/context"
+	"context"
 )
 
 // Service is the interface for all supported SCEP server operations.

--- a/server/service_logging.go
+++ b/server/service_logging.go
@@ -4,7 +4,7 @@ import (
 	"time"
 
 	"github.com/go-kit/kit/log"
-	"golang.org/x/net/context"
+	"context"
 )
 
 type loggingService struct {

--- a/server/transport.go
+++ b/server/transport.go
@@ -10,7 +10,7 @@ import (
 	"github.com/go-kit/kit/endpoint"
 	kitlog "github.com/go-kit/kit/log"
 	kithttp "github.com/go-kit/kit/transport/http"
-	"golang.org/x/net/context"
+	"context"
 )
 
 // ServiceHandler is an HTTP Handler for a SCEP endpoint.

--- a/server/transport_test.go
+++ b/server/transport_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 
 	kitlog "github.com/go-kit/kit/log"
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/micromdm/scep/server"
 )


### PR DESCRIPTION
…. Update all imports to "context" from "x/net/context".

Had to do this to update latest gokit