### PR TITLE
add response body to error

### DIFF
--- a/server/transport.go
+++ b/server/transport.go
@@ -118,9 +118,10 @@ func encodeSCEPResponse(ctx context.Context, w http.ResponseWriter, response int
 // DecodeSCEPResponse decodes a SCEP response
 func DecodeSCEPResponse(ctx context.Context, r *http.Response) (interface{}, error) {
 	if r.StatusCode != http.StatusOK && r.StatusCode >= 400 {
+		body, _ := ioutil.ReadAll(io.LimitReader(r.Body, 4096))
 		return nil, fmt.Errorf("http request failed with status %s, msg: %s",
 			r.Status,
-			io.LimitReader(r.Body, 4096),
+			string(body),
 		)
 	}
 	data, err := ioutil.ReadAll(io.LimitReader(r.Body, maxPayloadSize))


### PR DESCRIPTION
tries to read the response body instead of the mistakenly added io.LimitReader