### PR TITLE
Fixes the cert serial formatting in index.txt

### DIFF
--- a/depot/file/depot.go
+++ b/depot/file/depot.go
@@ -268,7 +268,10 @@ func (d *fileDepot) writeDB(cn string, serial *big.Int, filename string, cert *x
 	// Format of the caDB, see http://pki-tutorial.readthedocs.io/en/latest/cadb.html
 	//   STATUSFLAG  EXPIRATIONDATE  REVOCATIONDATE(or emtpy)	SERIAL_IN_HEX   CERTFILENAME_OR_'unknown'   Certificate_DN
 
-	serialHex := strings.ToUpper(fmt.Sprintf("%x", cert.SerialNumber))
+	serialHex := fmt.Sprintf("%X", cert.SerialNumber)
+	if len(serialHex)%2 == 1 {
+		serialHex = fmt.Sprintf("0%s", serialHex)
+	}
 
 	validDate := makeOpenSSLTime(cert.NotAfter)
 


### PR DESCRIPTION
Makes index.txt compatible with openssl.

After trying to generate a CRL with openssl, I noticed that openssl expects the serial numbers to have a leading 0 if the number of digits is not even.