### PR TITLE
Allow build without github ssh keys

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -28,7 +28,7 @@
 [[constraint]]
   branch = "sha256"
   name = "github.com/fullsailor/pkcs7"
-  source = "git@github.com:groob/pkcs7"
+  source = "github.com/groob/pkcs7"
 
 [[constraint]]
   name = "github.com/go-kit/kit"


### PR DESCRIPTION
Get the pkcs7 package via https, not ssh