### PR TITLE
Build docker image from current build, not static version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,8 @@
-FROM alpine:3.5
+FROM alpine:3.6
 
-ENV SCEP_VERSION=v1.0.0
-RUN apk --no-cache add curl unzip && \
-    curl -L https://github.com/micromdm/scep/releases/download/${SCEP_VERSION}/scep.zip -o /scep.zip && \
-    unzip -p /scep.zip build/scepserver-linux-amd64 > /scep && \
-    rm /scep.zip && \
-    chmod a+x /scep && \
-    apk del curl unzip && \
-    echo 'b4af438c2cb0f9dda7a8253e49f6c9ec71492ebfe85c25334c16ed4a0499ebc4  scep' | sha256sum -c
+COPY ./build/scepserver-linux-amd64 /usr/bin/scepserver
+COPY ./build/scepclient-linux-amd64 /usr/bin/scepclient
 
 EXPOSE 8080
-VOLUME ["/depot"]
-CMD ["/scep"]
+
+ENTRYPOINT ["scepserver"]

--- a/README.md
+++ b/README.md
@@ -130,12 +130,13 @@ This most likely uses the `/certsrv/mscep` path instead. You will need to add th
 
 # Docker
 ```
-docker pull micromdm/scep
+docker build -t micromdm/scep:latest .
+
 # create CA
-docker run -it --rm -v /path/to/ca/folder:/depot micromdm/scep ./scep ca -init
+docker run -it --rm -v /path/to/ca/folder:/depot micromdm/scep:latest ca -init
 
 # run
-docker run -it --rm -v /path/to/ca/folder:/depot -p 8080:8080 micromdm/scep
+docker run -it --rm -v /path/to/ca/folder:/depot -p 8080:8080 micromdm/scep:latest
 ```
 
 # SCEP library


### PR DESCRIPTION
I found that the existing Dockerfile downloaded a release version and installed it in the image. I don't really see how that approach is usable other than for generating an image based on a specific release version of the SCEP server. In any case, the user should be able to download a specific version directly from Docker hub instead. 

With the Dockerfile in this pull request, the image is built using the compiled version of SCEP server/client.

The entrypoint is set to start the server, but the user can just override it on container start to start the scep client instead. 