### PR TITLE
Set a default CommonName on new CA certs

### DIFF
--- a/depot/bolt/depot.go
+++ b/depot/bolt/depot.go
@@ -266,7 +266,7 @@ func (db *Depot) CreateOrLoadCA(key *rsa.PrivateKey, years int, org, country str
 		StreetAddress:      nil,
 		PostalCode:         nil,
 		SerialNumber:       "",
-		CommonName:         "",
+		CommonName:         org,
 	}
 
 	subjectKeyID, err := generateSubjectKeyID(&key.PublicKey)

--- a/scep/testdata/testca/sceptest.mobileconfig
+++ b/scep/testdata/testca/sceptest.mobileconfig
@@ -7,7 +7,7 @@
 		<dict>
 			<key>PayloadContent</key>
 			<dict>
-				<key>Key Type</key>
+				<key>KeyType</key>
 				<string>RSA</string>
 				<key>Keysize</key>
 				<integer>1024</integer>


### PR DESCRIPTION
Fixes https://github.com/micromdm/micromdm/issues/381

Questions around #381 come up a lot in #micromdm chat on Mac Admins slack. I think a long term solution can be done as requested [here](https://github.com/micromdm/micromdm/issues/278) and either allow the user to set more from the command line or just let users do something like upload their own CA cert to be used.

I think it's worth making this small change so when users test out MicroMDM for the first time they don't think there's something wrong during enrollment.