### PR TITLE
Fix these error logs

### DIFF
--- a/cmd/scepserver/scepserver.go
+++ b/cmd/scepserver/scepserver.go
@@ -104,19 +104,19 @@ func main() {
 	}
 	allowRenewal, err := strconv.Atoi(*flClAllowRenewal)
 	if err != nil {
-		lginfo.Log("err", "No valid number for allowed renewal time : " + err.Error())
+		lginfo.Log("err", err, "msg", "No valid number for allowed renewal time")
 		os.Exit(1)
 	}
 	clientValidity, err := strconv.Atoi(*flClDuration)
 	if err != nil {
-		lginfo.Log("err", "No valid number for client cert validity : " + err.Error())
+		lginfo.Log("err", err, "msg", "No valid number for client cert validity")
 		os.Exit(1)
 	}
 	var csrVerifier csrverifier.CSRVerifier
 	if *flCSRVerifierExec > "" {
 		executableCSRVerifier, err := executablecsrverifier.New(*flCSRVerifierExec, lginfo)
 		if err != nil {
-			lginfo.Log("err", "Could not instantiate CSR verifier : " + err.Error())
+			lginfo.Log("err", err, "msg", "Could not instantiate CSR verifier")
 			os.Exit(1)
 		}
 		csrVerifier = executableCSRVerifier

--- a/cmd/scepserver/scepserver.go
+++ b/cmd/scepserver/scepserver.go
@@ -104,19 +104,19 @@ func main() {
 	}
 	allowRenewal, err := strconv.Atoi(*flClAllowRenewal)
 	if err != nil {
-		lginfo.Log("No valid number for allowed renewal time : ", err)
+		lginfo.Log("err", "No valid number for allowed renewal time : ", err)
 		os.Exit(1)
 	}
 	clientValidity, err := strconv.Atoi(*flClDuration)
 	if err != nil {
-		lginfo.Log("No valid number for client cert validity : ", err)
+		lginfo.Log("err", "No valid number for client cert validity : ", err)
 		os.Exit(1)
 	}
 	var csrVerifier csrverifier.CSRVerifier
 	if *flCSRVerifierExec > "" {
 		executableCSRVerifier, err := executablecsrverifier.New(*flCSRVerifierExec, lginfo)
 		if err != nil {
-			lginfo.Log("Could not instantiate CSR verifier : ", err)
+			lginfo.Log("err", "Could not instantiate CSR verifier : ", err)
 			os.Exit(1)
 		}
 		csrVerifier = executableCSRVerifier

--- a/cmd/scepserver/scepserver.go
+++ b/cmd/scepserver/scepserver.go
@@ -104,19 +104,19 @@ func main() {
 	}
 	allowRenewal, err := strconv.Atoi(*flClAllowRenewal)
 	if err != nil {
-		lginfo.Log("err", "No valid number for allowed renewal time : ", err)
+		lginfo.Log("err", "No valid number for allowed renewal time : " + err.Error())
 		os.Exit(1)
 	}
 	clientValidity, err := strconv.Atoi(*flClDuration)
 	if err != nil {
-		lginfo.Log("err", "No valid number for client cert validity : ", err)
+		lginfo.Log("err", "No valid number for client cert validity : " + err.Error())
 		os.Exit(1)
 	}
 	var csrVerifier csrverifier.CSRVerifier
 	if *flCSRVerifierExec > "" {
 		executableCSRVerifier, err := executablecsrverifier.New(*flCSRVerifierExec, lginfo)
 		if err != nil {
-			lginfo.Log("err", "Could not instantiate CSR verifier : ", err)
+			lginfo.Log("err", "Could not instantiate CSR verifier : " + err.Error())
 			os.Exit(1)
 		}
 		csrVerifier = executableCSRVerifier


### PR DESCRIPTION
Format for logger.Log() params is pairs of name and attribute.
Without this change, the program dies with no output.

Verify by starting the server with an invalid argument to -csrverifierexec