### PR TITLE
changed date conversion method for 32 bits architecture

### DIFF
--- a/depot/file/depot.go
+++ b/depot/file/depot.go
@@ -198,11 +198,11 @@ func (d *fileDepot) HasCN(cn string, allowTime int, cert *x509.Certificate, revo
 				addDB.WriteString(line + "\n")
 				// Test & add certificate candidates, if any
 			} else if strings.HasPrefix(line, "V\t") {
-				issueDate, err := strconv.Atoi(strings.Replace(strings.Split(line, "\t")[1], "Z", "", 1))
+				issueDate, err := strconv.ParseInt(strings.Replace(strings.Split(line, "\t")[1], "Z", "", 1), 10, 64)
 				if err != nil {
 					return false, errors.New("Could not get expiry date from ca db")
 				}
-				minimalRenewDate, err := strconv.Atoi(strings.Replace(makeOpenSSLTime(time.Now().AddDate(0, 0, allowTime).UTC()), "Z", "", 1))
+				minimalRenewDate, err := strconv.ParseInt(strings.Replace(makeOpenSSLTime(time.Now().AddDate(0, 0, allowTime).UTC()), "Z", "", 1), 10, 64)
 				if err != nil {
 					return false, errors.New("Could not calculate expiry date")
 				}


### PR DESCRIPTION
the Atoi method to convert the date does not work on 32 bits architectures. I propose to replace this with ParseInt as it seems to work both on 32 and 64 bits architectures.