### PR TITLE
Add option to store CA PEM and key in a sub-directory of depot

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,10 @@ scepclient -private-key client.key -server-url=https://scep.example.com:4321/cer
 # Server Usage
 
 The default flags configure and run the scep server.  
-depot must be the path to a folder with `ca.pem` and `ca.key` files. 
+`depot` must be the path to a folder with `ca.pem` and `ca.key` files.
+
+Can optionally specify `casubdir` to store the `ca.pem` and `ca.key`
+files in a sub-directory of the depot.
 
 If you don't already have a CA to use, you can create one using the `scep ca` subcommand.
 
@@ -58,7 +61,9 @@ Usage of ./cmd/scepserver/scepserver:
   -debug
     	enable debug logging
   -depot string
-    	path to ca folder (default "depot")
+    	path to certificates folder (default "depot")
+  -casubdir string
+    	sub-path for the ca folder, under the depot
   -log-json
     	output JSON logs
   -port string

--- a/cmd/scepserver/scepserver.go
+++ b/cmd/scepserver/scepserver.go
@@ -51,7 +51,8 @@ func main() {
 	var (
 		flVersion           = flag.Bool("version", false, "prints version information")
 		flPort              = flag.String("port", envString("SCEP_HTTP_LISTEN_PORT", "8080"), "port to listen on")
-		flDepotPath         = flag.String("depot", envString("SCEP_FILE_DEPOT", "depot"), "path to ca folder")
+		flDepotPath         = flag.String("depot", envString("SCEP_FILE_DEPOT", "depot"), "path to certificates folder")
+		flDepotCaPath       = flag.String("casubdir", envString("SCEP_CA_SUBDIR", ""), "sub-path for the ca folder, under the depot")
 		flCAPass            = flag.String("capass", envString("SCEP_CA_PASS", ""), "passwd for the ca.key")
 		flClDuration        = flag.String("crtvalid", envString("SCEP_CERT_VALID", "365"), "validity for new client certificates in days")
 		flClAllowRenewal    = flag.String("allowrenew", envString("SCEP_CERT_RENEW", "14"), "do not allow renewal until n days before expiry, set to 0 to always allow")
@@ -96,7 +97,7 @@ func main() {
 	var err error
 	var depot depot.Depot // cert storage
 	{
-		depot, err = file.NewFileDepot(*flDepotPath)
+		depot, err = file.NewFileDepot(*flDepotPath, *flDepotCaPath)
 		if err != nil {
 			lginfo.Log("err", err)
 			os.Exit(1)

--- a/depot/file/depot.go
+++ b/depot/file/depot.go
@@ -19,22 +19,23 @@ import (
 )
 
 // NewFileDepot returns a new cert depot.
-func NewFileDepot(path string) (*fileDepot, error) {
+func NewFileDepot(path string, caSubPath string) (*fileDepot, error) {
 	f, err := os.OpenFile(fmt.Sprintf("%s/index.txt", path),
 		os.O_RDONLY|os.O_CREATE, 0666)
 	if err != nil {
 		return nil, err
 	}
 	defer f.Close()
-	return &fileDepot{dirPath: path}, nil
+	return &fileDepot{dirPath: path, caSubDirPath: caSubPath}, nil
 }
 
 type fileDepot struct {
 	dirPath string
+	caSubDirPath string
 }
 
 func (d *fileDepot) CA(pass []byte) ([]*x509.Certificate, *rsa.PrivateKey, error) {
-	caPEM, err := d.getFile("ca.pem")
+	caPEM, err := d.getFile(fmt.Sprintf("%s/ca.pem", d.caSubDirPath))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -42,7 +43,7 @@ func (d *fileDepot) CA(pass []byte) ([]*x509.Certificate, *rsa.PrivateKey, error
 	if err != nil {
 		return nil, nil, err
 	}
-	keyPEM, err := d.getFile("ca.key")
+	keyPEM, err := d.getFile(fmt.Sprintf("%s/ca.key", d.caSubDirPath))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/server/transport_test.go
+++ b/server/transport_test.go
@@ -91,7 +91,7 @@ func newServer(t *testing.T, opts ...scepserver.ServiceOption) (*httptest.Server
 	var err error
 	var depot depot.Depot // cert storage
 	{
-		depot, err = filedepot.NewFileDepot("../scep/testdata/testca")
+		depot, err = filedepot.NewFileDepot("../scep/testdata/testca", "")
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
I was struggling to get this running in Kubernetes because of the need for having the `ca.pem` and `ca.key` files in the same (writable) directory where the generated certificates are stored.

By allowing for the CA files to be stored in a sub-directory this problem becomes easy to solve by mounting 2 volumes in effectively separate directories.

If the `casubdir` sub-path is not specified it will default to looking for the CA files in the main depot folder, so no breaking changes.