### PR TITLE
Copy email addresses from CSR SANs to the X509 template

### DIFF
--- a/server/service.go
+++ b/server/service.go
@@ -145,6 +145,7 @@ func (svc *service) PKIOperation(ctx context.Context, data []byte) ([]byte, erro
 			x509.ExtKeyUsageClientAuth,
 		},
 		SignatureAlgorithm: csr.SignatureAlgorithm,
+		EmailAddresses:     csr.EmailAddresses,
 	}
 
 	certRep, err := msg.SignCSR(ca, svc.caKey, tmpl)


### PR DESCRIPTION
This allows generating certificates that can be used for purposes such as VPN authentication, where it might be desirable to identify the user by their email address.