### PR TITLE
Accept ECDSA keys in the scep core module

### DIFF
--- a/scep/scep.go
+++ b/scep/scep.go
@@ -6,6 +6,8 @@ package scep
 import (
 	"bytes"
 	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha1"
@@ -660,8 +662,10 @@ func generateSubjectKeyID(pub crypto.PublicKey) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
+	case *ecdsa.PublicKey:
+		pubBytes = elliptic.Marshal(pub.Curve, pub.X, pub.Y)
 	default:
-		return nil, errors.New("only RSA public key is supported")
+		return nil, errors.New("only ECDSA and RSA public keys are supported")
 	}
 
 	hash := sha1.Sum(pubBytes)


### PR DESCRIPTION
We are experimenting with SCEP, and we had to do this modification to allow CSR with EC keys. This PR is far from ideal. There are [three](https://github.com/micromdm/scep/blob/e9687bac0bd7c9ad3d508b070308a9dacefb8f47/depot/bolt/depot.go#L321) [other](https://github.com/micromdm/scep/blob/a136542b4bc9312ba88f1beaf1369d67bc744614/cmd/scepserver/scepserver.go#L318) [places](https://github.com/micromdm/scep/blob/e9687bac0bd7c9ad3d508b070308a9dacefb8f47/server/service.go#L297) where the same function is implemented in this repository. It would probably need some extra patching too, or a refactoring. This is more to start a conversation.