### PR TITLE
Pluggable CSR signing framework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ deps: gomodcheck
 	@go mod download
 
 test:
+	go test -cover ./...
+
+testrace:
 	go test -cover -race ./...
 
 build: build-scepclient build-scepserver

--- a/challenge/challenge.go
+++ b/challenge/challenge.go
@@ -15,7 +15,7 @@ type Store interface {
 	HasChallenge(pw string) (bool, error)
 }
 
-func csrSignerMiddleWare(store Store, next scepserver.CSRSignerFunc) scepserver.CSRSignerFunc {
+func csrSignerMiddleWare(store Store, next scepserver.CSRSigner) scepserver.CSRSignerFunc {
 	return func(m *scep.CSRReqMessage) (*x509.Certificate, error) {
 		// TODO: this was only verified in the old version if our MessageType was PKCSReq
 		valid, err := store.HasChallenge(m.ChallengePassword)
@@ -30,8 +30,8 @@ func csrSignerMiddleWare(store Store, next scepserver.CSRSignerFunc) scepserver.
 }
 
 // NewCSRSignerMiddleware creates a new middleware adaptor
-func NewCSRSignerMiddleware(store Store) func(scepserver.CSRSignerFunc) scepserver.CSRSignerFunc {
-	return func(f scepserver.CSRSignerFunc) scepserver.CSRSignerFunc {
+func NewCSRSignerMiddleware(store Store) func(scepserver.CSRSigner) scepserver.CSRSigner {
+	return func(f scepserver.CSRSigner) scepserver.CSRSigner {
 		return csrSignerMiddleWare(store, f)
 	}
 }

--- a/challenge/challenge.go
+++ b/challenge/challenge.go
@@ -1,8 +1,37 @@
 // Package challenge defines an interface for a dynamic challenge password cache.
 package challenge
 
+import (
+	"crypto/x509"
+	"errors"
+
+	"github.com/micromdm/scep/scep"
+	scepserver "github.com/micromdm/scep/server"
+)
+
 // Store is a dynamic challenge password cache.
 type Store interface {
 	SCEPChallenge() (string, error)
 	HasChallenge(pw string) (bool, error)
+}
+
+func csrSignerMiddleWare(store Store, next scepserver.CSRSignerFunc) scepserver.CSRSignerFunc {
+	return func(m *scep.CSRReqMessage) (*x509.Certificate, error) {
+		// TODO: this was only verified in the old version if our MessageType was PKCSReq
+		valid, err := store.HasChallenge(m.ChallengePassword)
+		if err != nil {
+			return nil, err
+		}
+		if !valid {
+			return nil, errors.New("invalid SCEP challenge")
+		}
+		return next.SignCSR(m)
+	}
+}
+
+// NewCSRSignerMiddleware creates a new middleware adaptor
+func NewCSRSignerMiddleware(store Store) func(scepserver.CSRSignerFunc) scepserver.CSRSignerFunc {
+	return func(f scepserver.CSRSignerFunc) scepserver.CSRSignerFunc {
+		return csrSignerMiddleWare(store, f)
+	}
 }

--- a/challenge/challenge_bolt_test.go
+++ b/challenge/challenge_bolt_test.go
@@ -1,0 +1,99 @@
+package challenge
+
+import (
+	"crypto/x509"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/boltdb/bolt"
+	challengestore "github.com/micromdm/scep/challenge/bolt"
+	"github.com/micromdm/scep/scep"
+)
+
+func TestDynamicChallenge(t *testing.T) {
+	db, err := openTempBolt("scep-challenge")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	depot, err := challengestore.NewBoltDepot(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// use the exported interface
+	store := Store(depot)
+
+	// get first challenge
+	challengePassword, err := store.SCEPChallenge()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if challengePassword == "" {
+		t.Error("empty challenge returned")
+	}
+
+	// test store API
+	valid, err := store.HasChallenge(challengePassword)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if valid != true {
+		t.Error("challenge just acquired is not valid")
+	}
+	valid, err = store.HasChallenge(challengePassword)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if valid != false {
+		t.Error("challenge should not be valid twice")
+	}
+
+	// get another challenge
+	challengePassword, err = store.SCEPChallenge()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if challengePassword == "" {
+		t.Error("empty challenge returned")
+	}
+
+	// test CSRSigner middleware
+	nullSigner := func(*scep.CSRReqMessage) (*x509.Certificate, error) {
+		return nil, nil
+	}
+	mw := NewCSRSignerMiddleware(depot)
+	signer := mw(nullSigner)
+
+	csrReq := &scep.CSRReqMessage{
+		ChallengePassword: challengePassword,
+	}
+
+	_, err = signer.SignCSR(csrReq)
+	if err != nil {
+		t.Error(err)
+	}
+
+	_, err = signer.SignCSR(csrReq)
+	if err == nil {
+		t.Error("challenge should not be valid twice")
+	}
+
+}
+
+func openTempBolt(prefix string) (*bolt.DB, error) {
+	f, err := ioutil.TempFile("", prefix+"-")
+	if err != nil {
+		return nil, err
+	}
+	f.Close()
+	err = os.Remove(f.Name())
+	if err != nil {
+		return nil, err
+	}
+
+	return bolt.Open(f.Name(), 0644, nil)
+}

--- a/challenge/challenge_bolt_test.go
+++ b/challenge/challenge_bolt_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/boltdb/bolt"
 	challengestore "github.com/micromdm/scep/challenge/bolt"
 	"github.com/micromdm/scep/scep"
+	scepserver "github.com/micromdm/scep/server"
 )
 
 func TestDynamicChallenge(t *testing.T) {
@@ -62,9 +63,9 @@ func TestDynamicChallenge(t *testing.T) {
 	}
 
 	// test CSRSigner middleware
-	nullSigner := func(*scep.CSRReqMessage) (*x509.Certificate, error) {
+	nullSigner := scepserver.CSRSignerFunc(func(*scep.CSRReqMessage) (*x509.Certificate, error) {
 		return nil, nil
-	}
+	})
 	mw := NewCSRSignerMiddleware(depot)
 	signer := mw(nullSigner)
 

--- a/csrverifier/csrverifier.go
+++ b/csrverifier/csrverifier.go
@@ -14,7 +14,7 @@ type CSRVerifier interface {
 	Verify(data []byte) (bool, error)
 }
 
-func csrSignerMiddleWare(verifier CSRVerifier, next scepserver.CSRSignerFunc) scepserver.CSRSignerFunc {
+func csrSignerMiddleWare(verifier CSRVerifier, next scepserver.CSRSigner) scepserver.CSRSignerFunc {
 	return func(m *scep.CSRReqMessage) (*x509.Certificate, error) {
 		result, err := verifier.Verify(m.RawDecrypted)
 		if err != nil {
@@ -28,8 +28,8 @@ func csrSignerMiddleWare(verifier CSRVerifier, next scepserver.CSRSignerFunc) sc
 }
 
 // NewCSRSignerMiddleware creates a new middleware adaptor
-func NewCSRSignerMiddleware(verifier CSRVerifier) func(scepserver.CSRSignerFunc) scepserver.CSRSignerFunc {
-	return func(f scepserver.CSRSignerFunc) scepserver.CSRSignerFunc {
+func NewCSRSignerMiddleware(verifier CSRVerifier) func(scepserver.CSRSigner) scepserver.CSRSigner {
+	return func(f scepserver.CSRSigner) scepserver.CSRSigner {
 		return csrSignerMiddleWare(verifier, f)
 	}
 }

--- a/csrverifier/csrverifier.go
+++ b/csrverifier/csrverifier.go
@@ -1,7 +1,35 @@
 // Package csrverifier defines an interface for CSR verification.
 package csrverifier
 
-// Verify the raw decrypted CSR.
+import (
+	"crypto/x509"
+	"errors"
+
+	"github.com/micromdm/scep/scep"
+	scepserver "github.com/micromdm/scep/server"
+)
+
+// CSRVerifier verifies the raw decrypted CSR.
 type CSRVerifier interface {
 	Verify(data []byte) (bool, error)
+}
+
+func csrSignerMiddleWare(verifier CSRVerifier, next scepserver.CSRSignerFunc) scepserver.CSRSignerFunc {
+	return func(m *scep.CSRReqMessage) (*x509.Certificate, error) {
+		result, err := verifier.Verify(m.RawDecrypted)
+		if err != nil {
+			return nil, err
+		}
+		if !result {
+			return nil, errors.New("CSR failed verification")
+		}
+		return next.SignCSR(m)
+	}
+}
+
+// NewCSRSignerMiddleware creates a new middleware adaptor
+func NewCSRSignerMiddleware(verifier CSRVerifier) func(scepserver.CSRSignerFunc) scepserver.CSRSignerFunc {
+	return func(f scepserver.CSRSignerFunc) scepserver.CSRSignerFunc {
+		return csrSignerMiddleWare(verifier, f)
+	}
 }

--- a/depot/signer.go
+++ b/depot/signer.go
@@ -1,0 +1,113 @@
+package depot
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha1"
+	"crypto/x509"
+	"encoding/asn1"
+	"errors"
+	"math/big"
+	"time"
+
+	scepserver "github.com/micromdm/scep/server"
+
+	"github.com/micromdm/scep/scep"
+)
+
+// CSRSigner returns a CSRSignerFunc for use in new scepserver service
+func CSRSigner(depot Depot, allowRenewal, clientValidity int, caPass string) scepserver.CSRSignerFunc {
+	return func(m *scep.CSRReqMessage) (*x509.Certificate, error) {
+		csr := m.CSR
+		id, err := generateSubjectKeyID(csr.PublicKey)
+		if err != nil {
+			return nil, err
+		}
+
+		serial, err := depot.Serial()
+		if err != nil {
+			return nil, err
+		}
+
+		// create cert template
+		tmpl := &x509.Certificate{
+			SerialNumber: serial,
+			Subject:      csr.Subject,
+			NotBefore:    time.Now().Add(-600).UTC(),
+			NotAfter:     time.Now().AddDate(0, 0, clientValidity).UTC(),
+			SubjectKeyId: id,
+			KeyUsage:     x509.KeyUsageDigitalSignature,
+			ExtKeyUsage: []x509.ExtKeyUsage{
+				x509.ExtKeyUsageClientAuth,
+			},
+			SignatureAlgorithm: csr.SignatureAlgorithm,
+			EmailAddresses:     csr.EmailAddresses,
+		}
+
+		crts, key, err := depot.CA([]byte(caPass))
+		ca := crts[0]
+		// sign the CSR creating a DER encoded cert
+		crtBytes, err := x509.CreateCertificate(rand.Reader, tmpl, ca, m.CSR.PublicKey, key)
+		if err != nil {
+			return nil, err
+		}
+		// parse the certificate
+		crt, err := x509.ParseCertificate(crtBytes)
+		if err != nil {
+			return nil, err
+		}
+
+		name := certName(crt)
+
+		// Test if this certificate is already in the CADB, revoke if needed
+		// revocation is done if the validity of the existing certificate is
+		// less than allowRenewal (14 days by default)
+		_, err = depot.HasCN(name, allowRenewal, crt, false)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := depot.Put(name, crt); err != nil {
+			return nil, err
+		}
+
+		return crt, nil
+	}
+}
+
+func certName(crt *x509.Certificate) string {
+	if crt.Subject.CommonName != "" {
+		return crt.Subject.CommonName
+	}
+	return string(crt.Signature)
+}
+
+// rsaPublicKey reflects the ASN.1 structure of a PKCS#1 public key.
+type rsaPublicKey struct {
+	N *big.Int
+	E int
+}
+
+// GenerateSubjectKeyID generates SubjectKeyId used in Certificate
+// ID is 160-bit SHA-1 hash of the value of the BIT STRING subjectPublicKey
+func generateSubjectKeyID(pub crypto.PublicKey) ([]byte, error) {
+	var pubBytes []byte
+	var err error
+	switch pub := pub.(type) {
+	case *rsa.PublicKey:
+		pubBytes, err = asn1.Marshal(rsaPublicKey{
+			N: pub.N,
+			E: pub.E,
+		})
+		if err != nil {
+			return nil, err
+		}
+	default:
+		return nil, errors.New("only RSA public key is supported")
+	}
+
+	hash := sha1.Sum(pubBytes)
+
+	return hash[:], nil
+}

--- a/scep/scep.go
+++ b/scep/scep.go
@@ -420,24 +420,13 @@ func (msg *PKIMessage) Fail(crtAuth *x509.Certificate, keyAuth *rsa.PrivateKey, 
 
 }
 
-// SignCSR creates an x509.Certificate based on a template and Cert Authority credentials
-// returns a new PKIMessage with CertRep data
-func (msg *PKIMessage) SignCSR(crtAuth *x509.Certificate, keyAuth *rsa.PrivateKey, template *x509.Certificate) (*PKIMessage, error) {
+// Success returns a new PKIMessage with CertRep data using an already-issued certificate
+func (msg *PKIMessage) Success(crtAuth *x509.Certificate, keyAuth *rsa.PrivateKey, crt *x509.Certificate) (*PKIMessage, error) {
 	// check if CSRReqMessage has already been decrypted
 	if msg.CSRReqMessage.CSR == nil {
 		if err := msg.DecryptPKIEnvelope(crtAuth, keyAuth); err != nil {
 			return nil, err
 		}
-	}
-	// sign the CSR creating a DER encoded cert
-	crtBytes, err := x509.CreateCertificate(rand.Reader, template, crtAuth, msg.CSRReqMessage.CSR.PublicKey, keyAuth)
-	if err != nil {
-		return nil, err
-	}
-	// parse the certificate
-	crt, err := x509.ParseCertificate(crtBytes)
-	if err != nil {
-		return nil, err
 	}
 
 	// create a degenerate cert structure

--- a/scep/scep_test.go
+++ b/scep/scep_test.go
@@ -89,7 +89,16 @@ func TestSignCSR(t *testing.T) {
 			x509.ExtKeyUsageClientAuth,
 		},
 	}
-	certRep, err := msg.SignCSR(cacert, cakey, tmpl)
+	// sign the CSR creating a DER encoded cert
+	crtBytes, err := x509.CreateCertificate(rand.Reader, tmpl, cacert, csr.PublicKey, cakey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	crt, err := x509.ParseCertificate(crtBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certRep, err := msg.Success(cacert, cakey, crt)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/service.go
+++ b/server/service.go
@@ -2,19 +2,11 @@ package scepserver
 
 import (
 	"context"
-	"crypto"
 	"crypto/rsa"
-	"crypto/sha1"
 	"crypto/x509"
-	"encoding/asn1"
 	"errors"
-	"math/big"
-	"time"
 
 	"github.com/go-kit/kit/log"
-	"github.com/micromdm/scep/challenge"
-	"github.com/micromdm/scep/csrverifier"
-	"github.com/micromdm/scep/depot"
 	"github.com/micromdm/scep/scep"
 )
 
@@ -39,30 +31,32 @@ type Service interface {
 	GetNextCACert(ctx context.Context) ([]byte, error)
 }
 
+// CSRSignerFunc is an adapter for CSR signing by the CA/RA
+type CSRSignerFunc func(*scep.CSRReqMessage) (*x509.Certificate, error)
+
+// SignCSR calls f(m)
+func (f CSRSignerFunc) SignCSR(m *scep.CSRReqMessage) (*x509.Certificate, error) {
+	return f(m)
+}
+
 type service struct {
-	depot                   depot.Depot
-	ca                      []*x509.Certificate // CA cert or chain
-	caKey                   *rsa.PrivateKey
-	caKeyPassword           []byte
-	csrTemplate             *x509.Certificate
-	challengePassword       string
-	supportDynamciChallenge bool
-	dynamicChallengeStore   challenge.Store
-	csrVerifier             csrverifier.CSRVerifier
-	allowRenewal            int // days before expiry, 0 to disable
-	clientValidity          int // client cert validity in days
+	// The service certificate and key for SCEP exchanges. These are
+	// quite likely the same as the CA keypair but may be its own SCEP
+	// specific keypair in the case of e.g. RA (proxy) operation.
+	crt *x509.Certificate
+	key *rsa.PrivateKey
+
+	// Optional additional CA certificates for e.g. RA (proxy) use.
+	// Only used in this service when responding to GetCACert.
+	addlCa []*x509.Certificate
+
+	// The (chainable) CSR signing function. Intended to handle all
+	// SCEP request functionality such as CSR & challenge checking, CA
+	// issuance, RA proxying, etc.
+	signer CSRSignerFunc
 
 	/// info logging is implemented in the service middleware layer.
 	debugLogger log.Logger
-}
-
-// SCEPChallenge returns a brand new, random dynamic challenge.
-func (svc *service) SCEPChallenge() (string, error) {
-	if !svc.supportDynamciChallenge {
-		return svc.challengePassword, nil
-	}
-
-	return svc.dynamicChallengeStore.SCEPChallenge()
 }
 
 func (svc *service) GetCACaps(ctx context.Context) ([]byte, error) {
@@ -71,14 +65,16 @@ func (svc *service) GetCACaps(ctx context.Context) ([]byte, error) {
 }
 
 func (svc *service) GetCACert(ctx context.Context) ([]byte, int, error) {
-	if len(svc.ca) == 0 {
-		return nil, 0, errors.New("missing CA Cert")
+	if svc.crt == nil {
+		return nil, 0, errors.New("missing CA certificate")
 	}
-	if len(svc.ca) == 1 {
-		return svc.ca[0].Raw, 1, nil
+	if len(svc.addlCa) < 1 {
+		return svc.crt.Raw, 1, nil
 	}
-	data, err := scep.DegenerateCertificates(svc.ca)
-	return data, len(svc.ca), err
+	certs := []*x509.Certificate{svc.crt}
+	certs = append(certs, svc.addlCa...)
+	data, err := scep.DegenerateCertificates(certs)
+	return data, len(svc.addlCa) + 1, err
 }
 
 func (svc *service) PKIOperation(ctx context.Context, data []byte) ([]byte, error) {
@@ -86,171 +82,27 @@ func (svc *service) PKIOperation(ctx context.Context, data []byte) ([]byte, erro
 	if err != nil {
 		return nil, err
 	}
-	ca := svc.ca[0]
-	if err := msg.DecryptPKIEnvelope(svc.ca[0], svc.caKey); err != nil {
+	if err := msg.DecryptPKIEnvelope(svc.crt, svc.key); err != nil {
 		return nil, err
 	}
 
-	// validate challenge passwords
-	if msg.MessageType == scep.PKCSReq {
-		CSRIsValid := false
-
-		if svc.csrVerifier != nil {
-			result, err := svc.csrVerifier.Verify(msg.CSRReqMessage.RawDecrypted)
-			if err != nil {
-				return nil, err
-			}
-			CSRIsValid = result
-			if !CSRIsValid {
-				svc.debugLogger.Log("err", "CSR is not valid")
-			}
-		} else {
-			CSRIsValid = svc.challengePasswordMatch(msg.CSRReqMessage.ChallengePassword)
-			if !CSRIsValid {
-				svc.debugLogger.Log("err", "scep challenge password does not match")
-			}
-		}
-
-		if !CSRIsValid {
-			certRep, err := msg.Fail(ca, svc.caKey, scep.BadRequest)
-			if err != nil {
-				return nil, err
-			}
-			return certRep.Raw, nil
-		}
-	}
-
-	csr := msg.CSRReqMessage.CSR
-	id, err := generateSubjectKeyID(csr.PublicKey)
+	crt, err := svc.signer.SignCSR(msg.CSRReqMessage)
 	if err != nil {
-		return nil, err
+		svc.debugLogger.Log("msg", "failed to sign CSR", "err", err)
+		certRep, err := msg.Fail(svc.crt, svc.key, scep.BadRequest)
+		return certRep.Raw, err
 	}
 
-	serial, err := svc.depot.Serial()
-	if err != nil {
-		return nil, err
-	}
-
-	duration := svc.clientValidity
-
-	// create cert template
-	tmpl := &x509.Certificate{
-		SerialNumber: serial,
-		Subject:      csr.Subject,
-		NotBefore:    time.Now().Add(-600).UTC(),
-		NotAfter:     time.Now().AddDate(0, 0, duration).UTC(),
-		SubjectKeyId: id,
-		KeyUsage:     x509.KeyUsageDigitalSignature,
-		ExtKeyUsage: []x509.ExtKeyUsage{
-			x509.ExtKeyUsageClientAuth,
-		},
-		SignatureAlgorithm: csr.SignatureAlgorithm,
-		DNSNames:           csr.DNSNames,
-		EmailAddresses:     csr.EmailAddresses,
-		IPAddresses:        csr.IPAddresses,
-		URIs:               csr.URIs,
-	}
-
-	certRep, err := msg.SignCSR(ca, svc.caKey, tmpl)
-	if err != nil {
-		return nil, err
-	}
-
-	crt := certRep.CertRepMessage.Certificate
-	name := certName(crt)
-
-	// Test if this certificate is already in the CADB, revoke if needed
-	// revocation is done if the validity of the existing certificate is
-	// less than allowRenewal (14 days by default)
-	_, err = svc.depot.HasCN(name, svc.allowRenewal, crt, false)
-	if err != nil {
-		return nil, err
-	}
-
-	if err := svc.depot.Put(name, crt); err != nil {
-		return nil, err
-	}
-
-	return certRep.Raw, nil
-}
-
-func certName(crt *x509.Certificate) string {
-	if crt.Subject.CommonName != "" {
-		return crt.Subject.CommonName
-	}
-	return string(crt.Signature)
+	certRep, err := msg.Success(svc.crt, svc.key, crt)
+	return certRep.Raw, err
 }
 
 func (svc *service) GetNextCACert(ctx context.Context) ([]byte, error) {
 	panic("not implemented")
 }
 
-func (svc *service) challengePasswordMatch(pw string) bool {
-	if svc.challengePassword == "" && !svc.supportDynamciChallenge {
-		// empty password, don't validate
-		return true
-	}
-	if !svc.supportDynamciChallenge && svc.challengePassword == pw {
-		return true
-	}
-
-	if svc.supportDynamciChallenge {
-		valid, err := svc.dynamicChallengeStore.HasChallenge(pw)
-		if err != nil {
-			svc.debugLogger.Log(err)
-			return false
-		}
-		return valid
-	}
-
-	return false
-}
-
 // ServiceOption is a server configuration option
 type ServiceOption func(*service) error
-
-// WithCSRVerifier is an option argument to NewService
-// which allows setting a CSR verifier.
-func WithCSRVerifier(csrVerifier csrverifier.CSRVerifier) ServiceOption {
-	return func(s *service) error {
-		s.csrVerifier = csrVerifier
-		return nil
-	}
-}
-
-// ChallengePassword is an optional argument to NewService
-// which allows setting a preshared key for SCEP.
-func ChallengePassword(pw string) ServiceOption {
-	return func(s *service) error {
-		s.challengePassword = pw
-		return nil
-	}
-}
-
-// CAKeyPassword is an optional argument to NewService for
-// specifying the CA private key password.
-func CAKeyPassword(pw []byte) ServiceOption {
-	return func(s *service) error {
-		s.caKeyPassword = pw
-		return nil
-	}
-}
-
-// allowRenewal sets the days before expiry which we are allowed to renew (optional)
-func AllowRenewal(duration int) ServiceOption {
-	return func(s *service) error {
-		s.allowRenewal = duration
-		return nil
-	}
-}
-
-// ClientValidity sets the validity of signed client certs in days (optional parameter)
-func ClientValidity(duration int) ServiceOption {
-	return func(s *service) error {
-		s.clientValidity = duration
-		return nil
-	}
-}
 
 // WithLogger configures a logger for the SCEP Service.
 // By default, a no-op logger is used.
@@ -261,18 +113,47 @@ func WithLogger(logger log.Logger) ServiceOption {
 	}
 }
 
-func WithDynamicChallenges(cache challenge.Store) ServiceOption {
+// WithAddlCA appends an additional certificate to the slice of CA certs
+func WithAddlCA(ca *x509.Certificate) ServiceOption {
 	return func(s *service) error {
-		s.supportDynamciChallenge = true
-		s.dynamicChallengeStore = cache
+		s.addlCa = append(s.addlCa, ca)
+		return nil
+	}
+}
+
+func staticChallengePasswordCSRSignerMiddleware(pw string, next CSRSignerFunc) CSRSignerFunc {
+	return func(m *scep.CSRReqMessage) (*x509.Certificate, error) {
+		// TODO: this was only verified in the old version if our MessageType was PKCSReq
+		if pw != m.ChallengePassword {
+			return nil, errors.New("challenge password mismatch")
+		}
+		return next.SignCSR(m)
+	}
+}
+
+// WithStaticChallengePassword wraps the service signer function in
+// a middleware that checks for matching challenge passwords
+func WithStaticChallengePassword(pw string) ServiceOption {
+	return func(s *service) error {
+		s.signer = staticChallengePasswordCSRSignerMiddleware(pw, s.signer)
+		return nil
+	}
+}
+
+// WithCSRSignerMiddleware wraps the service
+func WithCSRSignerMiddleware(f func(CSRSignerFunc) CSRSignerFunc) ServiceOption {
+	return func(s *service) error {
+		s.signer = f(s.signer)
 		return nil
 	}
 }
 
 // NewService creates a new scep service
-func NewService(depot depot.Depot, opts ...ServiceOption) (Service, error) {
+func NewService(crt *x509.Certificate, key *rsa.PrivateKey, signer CSRSignerFunc, opts ...ServiceOption) (Service, error) {
 	s := &service{
-		depot:       depot,
+		crt:         crt,
+		key:         key,
+		signer:      signer,
 		debugLogger: log.NewNopLogger(),
 	}
 	for _, opt := range opts {
@@ -280,40 +161,5 @@ func NewService(depot depot.Depot, opts ...ServiceOption) (Service, error) {
 			return nil, err
 		}
 	}
-
-	var err error
-	s.ca, s.caKey, err = depot.CA(s.caKeyPassword)
-	if err != nil {
-		return nil, err
-	}
 	return s, nil
-}
-
-// rsaPublicKey reflects the ASN.1 structure of a PKCS#1 public key.
-type rsaPublicKey struct {
-	N *big.Int
-	E int
-}
-
-// GenerateSubjectKeyID generates SubjectKeyId used in Certificate
-// ID is 160-bit SHA-1 hash of the value of the BIT STRING subjectPublicKey
-func generateSubjectKeyID(pub crypto.PublicKey) ([]byte, error) {
-	var pubBytes []byte
-	var err error
-	switch pub := pub.(type) {
-	case *rsa.PublicKey:
-		pubBytes, err = asn1.Marshal(rsaPublicKey{
-			N: pub.N,
-			E: pub.E,
-		})
-		if err != nil {
-			return nil, err
-		}
-	default:
-		return nil, errors.New("only RSA public key is supported")
-	}
-
-	hash := sha1.Sum(pubBytes)
-
-	return hash[:], nil
 }

--- a/server/service.go
+++ b/server/service.go
@@ -87,6 +87,9 @@ func (svc *service) PKIOperation(ctx context.Context, data []byte) ([]byte, erro
 	}
 
 	crt, err := svc.signer.SignCSR(msg.CSRReqMessage)
+	if err == nil && crt == nil {
+		err = errors.New("no signed certificate")
+	}
 	if err != nil {
 		svc.debugLogger.Log("msg", "failed to sign CSR", "err", err)
 		certRep, err := msg.Fail(svc.crt, svc.key, scep.BadRequest)

--- a/server/transport_test.go
+++ b/server/transport_test.go
@@ -123,9 +123,9 @@ func newServer(t *testing.T, opts ...scepserver.ServiceOption) (*httptest.Server
 		depot = &noopDepot{depot}
 	}
 	crt, key, err := depot.CA([]byte{})
-	nullSigner := func(*scep.CSRReqMessage) (*x509.Certificate, error) {
+	nullSigner := scepserver.CSRSignerFunc(func(*scep.CSRReqMessage) (*x509.Certificate, error) {
 		return nil, nil
-	}
+	})
 	var svc scepserver.Service // scep service
 	{
 		svc, err = scepserver.NewService(crt[0], key, nullSigner)


### PR DESCRIPTION
*tl;dr* Changes internal API for how signing of certificates works in the scep server.

This PR changes the core organization of the SCEP server service in support of #112. The service itself (in `server/service.go`) is much simplified due to removing all CA functionality. In lieu of CA implementation details being in the server service we opted for a way to modularlize certificate signing (and any other duties that need to inspect and take action on the CSR). Thus the `scepserver.CSRSigner` interface:

```go
// CSRSigner is a handler for CSR signing by the CA/RA
//
// SignCSR should take the CSR in the CSRReqMessage and return a
// Certificate signed by the CA.
type CSRSigner interface {
	SignCSR(*scep.CSRReqMessage) (*x509.Certificate, error)
}
```

Due to the interface and associated adapter functions this also makes it possible to chain together these `CSRSigner`s to modularize most of the functionality we need — not so dissimilar from how `http.HandlerFunc` works. For example because `scep.CSRReqMessage` contains the parsed and raw CSR as well as the challenge password, the SCEP challenge password checking can just be a middleware over the actual CA implementation.

The other (minor, compared to the above) change is a separation of "service" certificates from the CA certificates. While for most users these are the same certs and keys (i.e. the SCEP protocol exchanges just use the same keypair as the CA) some users may want to use the SCEP service with another CA that has its own keypair, or as an RA (Registration Authority — a "proxy" of sorts). This change allows that.