### PR TITLE
Decode binary in GET requests. Closes #98.

### DIFF
--- a/server/transport.go
+++ b/server/transport.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 
 	kitlog "github.com/go-kit/kit/log"
 	kithttp "github.com/go-kit/kit/transport/http"
@@ -94,6 +95,14 @@ func message(r *http.Request) ([]byte, error) {
 		q := r.URL.Query()
 		if _, ok := q["message"]; ok {
 			msg = q.Get("message")
+		}
+		op := q.Get("operation")
+		if op == "PKIOperation" {
+			msg2, err := url.PathUnescape(msg);
+			if err != nil {
+				return nil, err
+			}
+			return base64.StdEncoding.DecodeString(msg2)
 		}
 		return []byte(msg), nil
 	case "POST":


### PR DESCRIPTION

This patch add decoding of base64-encoded messages in PKIOperation queries.
Tested against juniper (junos 20.1) client and found working. Juniper behaviour slightly
differs from already proposed idea:
a) it does not encodes all messages with base64, only PKIOperation. For example, 
with GetCACert query looks like  path="/scep?operation=GetCACert&message=CA-CERT-NAME"
(not encoded), and attempt to decode such string will lead to decoding failure (may be
GetCACert is not considered as binary, and only binary data shall be encoded per rfc).
b) before decoding, messages are unescaped.