### PR TITLE
Support simultaneous verification of CSR and Challenge Password

### DIFF
--- a/csrverifier/csrverifier.go
+++ b/csrverifier/csrverifier.go
@@ -10,5 +10,5 @@ type CSRVerifier interface {
 
 // Verify the CSR and Challenge together
 type CombinedVerifier interface {
-	Verify(ctx context.Context, data []byte, challenge string) (bool, error)
+	Validate(ctx context.Context, data []byte, challenge string) (bool, error)
 }

--- a/csrverifier/csrverifier.go
+++ b/csrverifier/csrverifier.go
@@ -1,7 +1,14 @@
 // Package csrverifier defines an interface for CSR verification.
 package csrverifier
 
+import "context"
+
 // Verify the raw decrypted CSR.
 type CSRVerifier interface {
 	Verify(data []byte) (bool, error)
+}
+
+// Verify the CSR and Challenge together
+type CombinedVerifier interface {
+	Verify(ctx context.Context, data []byte, challenge string) (bool, error)
 }

--- a/server/service.go
+++ b/server/service.go
@@ -85,7 +85,7 @@ func (svc *service) verify(ctx context.Context, rawCSR []byte, challengePassword
 	// Consider changing this so verifiers stack, instead of first one wins.
 
 	if svc.combinedVerifier != nil {
-		return svc.combinedVerifier.Verify(ctx, rawCSR, challengePassword)
+		return svc.combinedVerifier.Validate(ctx, rawCSR, challengePassword)
 	}
 
 	if svc.csrVerifier != nil {
@@ -119,7 +119,7 @@ func (svc *service) PKIOperation(ctx context.Context, data []byte) ([]byte, erro
 	if msg.MessageType == scep.PKCSReq {
 		isValid, err := svc.verify(ctx, msg.CSRReqMessage.RawDecrypted, msg.CSRReqMessage.ChallengePassword)
 		if err != nil {
-			svc.debugLogger.Log(err)
+			svc.debugLogger.Log("err", err)
 			return nil, err
 		}
 

--- a/server/service_bolt_test.go
+++ b/server/service_bolt_test.go
@@ -51,11 +51,23 @@ func TestDynamicChallenge(t *testing.T) {
 	}
 
 	impl := svc.(*service)
-	if !impl.challengePasswordMatch(challenge) {
-		t.Errorf("challenge password does not match")
+	{
+		result, err := impl.verify(context.TODO(), nil, challenge)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !result {
+			t.Errorf("challenge password does not match")
+		}
 	}
-	if impl.challengePasswordMatch(challenge) {
-		t.Errorf("challenge password matched but should only be used once")
+	{
+		result, err := impl.verify(context.TODO(), nil, challenge)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result {
+			t.Errorf("challenge password matched but should only be used once")
+		}
 	}
 
 }


### PR DESCRIPTION
Add a `WithCombinedVerifier` option, and associated interface, to verify the CSR and challenge password together. This allows the password to be a signature on the csr.
    
Additionally cleanup the logic around verification. This preserves the existing precedence, but should be more clear.

**Question for the maintainers:** I think it would be valuable in allowing something to modify the CSR before signing. I think there's an obvious hook for it, right here. What do y'all think? Should that be a different interface? Should this become ValidateAndRewrite ?