### PR TITLE
Acually use sigAlgo in CSR if the client supports it

### DIFF
--- a/cmd/scepclient/csr.go
+++ b/cmd/scepclient/csr.go
@@ -20,6 +20,7 @@ const (
 type csrOptions struct {
 	cn, org, country, ou, locality, province, challenge string
 	key                                                 *rsa.PrivateKey
+	sigAlgo                                             x509.SignatureAlgorithm
 }
 
 func loadOrMakeCSR(path string, opts *csrOptions) (*x509.CertificateRequest, error) {
@@ -43,7 +44,7 @@ func loadOrMakeCSR(path string, opts *csrOptions) (*x509.CertificateRequest, err
 	template := x509util.CertificateRequest{
 		CertificateRequest: x509.CertificateRequest{
 			Subject:            subject,
-			SignatureAlgorithm: x509.SHA1WithRSA,
+			SignatureAlgorithm: opts.sigAlgo,
 		},
 	}
 	if opts.challenge != "" {


### PR DESCRIPTION
The SHA1WithRSA signature algorithm is hardcoded even when it handled by scepclient.go.