### PR TITLE
Fix TestCaCert in service_bolt_test.go

### DIFF
--- a/server/service_bolt_test.go
+++ b/server/service_bolt_test.go
@@ -119,7 +119,7 @@ func TestCaCert(t *testing.T) {
 		tmpl := &scep.PKIMessage{
 			MessageType: scep.PKCSReq,
 			Recipients:  []*x509.Certificate{caCert},
-			SignerKey:   key,
+			SignerKey:   selfKey,
 			SignerCert:  signerCert,
 		}
 


### PR DESCRIPTION
This PR fixes TestCaCert function so that it passes.

The main problem was that CA private key was used instead of the signer (SCEP signer) key to sign CSRs.