### PR TITLE
Link CI badge to build history

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-![CI](https://github.com/micromdm/scep/workflows/CI/badge.svg)
+[![CI](https://github.com/micromdm/scep/workflows/CI/badge.svg)](https://github.com/micromdm/scep/actions)
+
 
 `scep` is a Simple Certificate Enrollment Protocol server and client
 


### PR DESCRIPTION
Currently this just links to the .SVG file.