### PR TITLE
Run CI on new commits to pull requests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
+    types: [opened, reopened, synchronize]
 
 jobs:
   test-build:


### PR DESCRIPTION
Current setup only runs build tests on new commits to master and new pull requests (based on `master`). This removes the `master` branch requirement from PRs and reruns builds on each new commit to PRs.