### PR TITLE
Encode CSRs only with certificates with KeyEncipherment KeyUsage

### DIFF
--- a/depot/bolt/depot.go
+++ b/depot/bolt/depot.go
@@ -279,7 +279,7 @@ func (db *Depot) CreateOrLoadCA(key *rsa.PrivateKey, years int, org, country str
 		Subject:            subject,
 		NotBefore:          time.Now().Add(-600).UTC(),
 		NotAfter:           time.Now().AddDate(years, 0, 0).UTC(),
-		KeyUsage:           x509.KeyUsageCertSign,
+		KeyUsage:           x509.KeyUsageCertSign | x509.KeyUsageKeyEncipherment,
 		ExtKeyUsage:        nil,
 		UnknownExtKeyUsage: nil,
 

--- a/scep/scep.go
+++ b/scep/scep.go
@@ -382,27 +382,27 @@ func (msg *PKIMessage) DecryptPKIEnvelope(cert *x509.Certificate, key *rsa.Priva
 func (msg *PKIMessage) Fail(crtAuth *x509.Certificate, keyAuth *rsa.PrivateKey, info FailInfo) (*PKIMessage, error) {
 	config := pkcs7.SignerInfoConfig{
 		ExtraSignedAttributes: []pkcs7.Attribute{
-			pkcs7.Attribute{
+			{
 				Type:  oidSCEPtransactionID,
 				Value: msg.TransactionID,
 			},
-			pkcs7.Attribute{
+			{
 				Type:  oidSCEPpkiStatus,
 				Value: FAILURE,
 			},
-			pkcs7.Attribute{
+			{
 				Type:  oidSCEPfailInfo,
 				Value: info,
 			},
-			pkcs7.Attribute{
+			{
 				Type:  oidSCEPmessageType,
 				Value: CertRep,
 			},
-			pkcs7.Attribute{
+			{
 				Type:  oidSCEPsenderNonce,
 				Value: msg.SenderNonce,
 			},
-			pkcs7.Attribute{
+			{
 				Type:  oidSCEPrecipientNonce,
 				Value: msg.SenderNonce,
 			},
@@ -466,23 +466,23 @@ func (msg *PKIMessage) Success(crtAuth *x509.Certificate, keyAuth *rsa.PrivateKe
 	// PKIMessageAttributes to be signed
 	config := pkcs7.SignerInfoConfig{
 		ExtraSignedAttributes: []pkcs7.Attribute{
-			pkcs7.Attribute{
+			{
 				Type:  oidSCEPtransactionID,
 				Value: msg.TransactionID,
 			},
-			pkcs7.Attribute{
+			{
 				Type:  oidSCEPpkiStatus,
 				Value: SUCCESS,
 			},
-			pkcs7.Attribute{
+			{
 				Type:  oidSCEPmessageType,
 				Value: CertRep,
 			},
-			pkcs7.Attribute{
+			{
 				Type:  oidSCEPsenderNonce,
 				Value: msg.SenderNonce,
 			},
-			pkcs7.Attribute{
+			{
 				Type:  oidSCEPrecipientNonce,
 				Value: msg.SenderNonce,
 			},
@@ -555,7 +555,11 @@ func NewCSRRequest(csr *x509.CertificateRequest, tmpl *PKIMessage, opts ...Optio
 	}
 
 	derBytes := csr.Raw
-	e7, err := pkcs7.Encrypt(derBytes, tmpl.Recipients)
+	recipients := filterCertificatesByKeyUsage(tmpl.Recipients, x509.KeyUsageKeyEncipherment)
+	if len(recipients) == 0 {
+		return nil, errors.New("no recipients that can be used for KeyEncipherment.")
+	}
+	e7, err := pkcs7.Encrypt(derBytes, recipients)
 	if err != nil {
 		return nil, err
 	}
@@ -585,15 +589,15 @@ func NewCSRRequest(csr *x509.CertificateRequest, tmpl *PKIMessage, opts ...Optio
 	// PKIMessageAttributes to be signed
 	config := pkcs7.SignerInfoConfig{
 		ExtraSignedAttributes: []pkcs7.Attribute{
-			pkcs7.Attribute{
+			{
 				Type:  oidSCEPtransactionID,
 				Value: tID,
 			},
-			pkcs7.Attribute{
+			{
 				Type:  oidSCEPmessageType,
 				Value: tmpl.MessageType,
 			},
-			pkcs7.Attribute{
+			{
 				Type:  oidSCEPsenderNonce,
 				Value: sn,
 			},
@@ -676,4 +680,13 @@ func generateSubjectKeyID(pub crypto.PublicKey) ([]byte, error) {
 	hash := sha1.Sum(pubBytes)
 
 	return hash[:], nil
+}
+
+func filterCertificatesByKeyUsage(recipients []*x509.Certificate, keyUsage x509.KeyUsage) (filtered []*x509.Certificate) {
+	for _, cert := range recipients {
+		if cert.KeyUsage&keyUsage == keyUsage {
+			filtered = append(filtered, cert)
+		}
+	}
+	return filtered
 }

--- a/scep/scep_test.go
+++ b/scep/scep_test.go
@@ -130,54 +130,55 @@ func TestSignCSR(t *testing.T) {
 	testParsePKIMessage(t, certRep.Raw)
 }
 
-type testNewCSRRequestStruct struct {
-	keyUsage        x509.KeyUsage
-	shouldCreateCSR bool
-}
-
-var testNewCSRRequestData = []testNewCSRRequestStruct{
-	{x509.KeyUsageDigitalSignature, false},
-	{x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature, true},
-}
-
 func TestNewCSRRequest(t *testing.T) {
-	key, err := newRSAKey(2048)
-	if err != nil {
-		t.Fatal(err)
-	}
-	derBytes, err := newCSR(key, "john.doe@example.com", "US", "com.apple.scep.2379B935-294B-4AF1-A213-9BD44A2C6688")
-	if err != nil {
-		t.Fatal(err)
-	}
-	csr, err := x509.ParseCertificateRequest(derBytes)
-	if err != nil {
-		t.Fatal(err)
-	}
-	clientcert, clientkey := loadClientCredentials(t)
-	for i, test := range testNewCSRRequestData {
-		cacert, cakey := createCaCertWithKeyUsage(t, test.keyUsage)
-		tmpl := &scep.PKIMessage{
-			MessageType: scep.PKCSReq,
-			Recipients:  []*x509.Certificate{cacert},
-			SignerCert:  clientcert,
-			SignerKey:   clientkey,
-		}
+	for _, test := range []struct {
+		testName        string
+		keyUsage        x509.KeyUsage
+		shouldCreateCSR bool
+	}{
+		{"KeyEncipherment not set", x509.KeyUsageDigitalSignature, false},
+		{"KeyEncipherment is set", x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature, true},
+	} {
+		test := test
+		t.Run(test.testName, func(t *testing.T) {
+			t.Parallel()
+			key, err := newRSAKey(2048)
+			if err != nil {
+				t.Fatal(err)
+			}
+			derBytes, err := newCSR(key, "john.doe@example.com", "US", "com.apple.scep.2379B935-294B-4AF1-A213-9BD44A2C6688")
+			if err != nil {
+				t.Fatal(err)
+			}
+			csr, err := x509.ParseCertificateRequest(derBytes)
+			if err != nil {
+				t.Fatal(err)
+			}
+			clientcert, clientkey := loadClientCredentials(t)
+			cacert, cakey := createCaCertWithKeyUsage(t, test.keyUsage)
+			tmpl := &scep.PKIMessage{
+				MessageType: scep.PKCSReq,
+				Recipients:  []*x509.Certificate{cacert},
+				SignerCert:  clientcert,
+				SignerKey:   clientkey,
+			}
 
-		pkcsreq, err := scep.NewCSRRequest(csr, tmpl)
-		if test.shouldCreateCSR && err != nil {
-			t.Fatalf("%d keyUsage: %d, failed creating a CSR request: %v", i, test.keyUsage, err)
-		}
-		if !test.shouldCreateCSR && err == nil {
-			t.Fatalf("%d keyUsage: %d, shouldn't have created a CSR: %v", i, test.keyUsage, err)
-		}
-		if !test.shouldCreateCSR {
-			return
-		}
-		msg := testParsePKIMessage(t, pkcsreq.Raw)
-		err = msg.DecryptPKIEnvelope(cacert, cakey)
-		if err != nil {
-			t.Fatal(err)
-		}
+			pkcsreq, err := scep.NewCSRRequest(csr, tmpl)
+			if test.shouldCreateCSR && err != nil {
+				t.Fatalf("keyUsage: %d, failed creating a CSR request: %v", test.keyUsage, err)
+			}
+			if !test.shouldCreateCSR && err == nil {
+				t.Fatalf("keyUsage: %d, shouldn't have created a CSR: %v", test.keyUsage, err)
+			}
+			if !test.shouldCreateCSR {
+				return
+			}
+			msg := testParsePKIMessage(t, pkcsreq.Raw)
+			err = msg.DecryptPKIEnvelope(cacert, cakey)
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
 	}
 }
 
@@ -221,22 +222,22 @@ func createCaCertWithKeyUsage(t *testing.T, keyUsage x509.KeyUsage) (*x509.Certi
 		t.Fatal(err)
 	}
 	subject := pkix.Name{
-		Country:            []string{"US"},
-		Organization:       []string{"MICROMDM"},
-		CommonName:         "MICROMDM SCEP CA",
+		Country:      []string{"US"},
+		Organization: []string{"MICROMDM"},
+		CommonName:   "MICROMDM SCEP CA",
 	}
 	subjectKeyID, err := generateSubjectKeyID(&key.PublicKey)
 	if err != nil {
 		t.Fatal(err)
 	}
 	authTemplate := x509.Certificate{
-		SerialNumber:       big.NewInt(1),
-		Subject:            subject,
-		NotBefore:          time.Now().Add(-600).UTC(),
-		NotAfter:           time.Now().AddDate(1, 0, 0).UTC(),
-		KeyUsage:           keyUsage,
-		IsCA:                        true,
-		SubjectKeyId:                subjectKeyID,
+		SerialNumber: big.NewInt(1),
+		Subject:      subject,
+		NotBefore:    time.Now().Add(-600).UTC(),
+		NotAfter:     time.Now().AddDate(1, 0, 0).UTC(),
+		KeyUsage:     keyUsage,
+		IsCA:         true,
+		SubjectKeyId: subjectKeyID,
 	}
 	crtBytes, err := x509.CreateCertificate(rand.Reader, &authTemplate, &authTemplate, &key.PublicKey, key)
 	if err != nil {
@@ -370,6 +371,7 @@ type rsaPublicKey struct {
 
 // GenerateSubjectKeyID generates SubjectKeyId used in Certificate
 // ID is 160-bit SHA-1 hash of the value of the BIT STRING subjectPublicKey
+// TODO(issue/138): generateSubjectKeyID function is duplicated 6 times
 func GenerateSubjectKeyID(pub crypto.PublicKey) ([]byte, error) {
 	var pubBytes []byte
 	var err error

--- a/scep/scep_test.go
+++ b/scep/scep_test.go
@@ -226,7 +226,7 @@ func createCaCertWithKeyUsage(t *testing.T, keyUsage x509.KeyUsage) (*x509.Certi
 		Organization: []string{"MICROMDM"},
 		CommonName:   "MICROMDM SCEP CA",
 	}
-	subjectKeyID, err := generateSubjectKeyID(&key.PublicKey)
+	subjectKeyID, err := GenerateSubjectKeyID(&key.PublicKey)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -248,29 +248,6 @@ func createCaCertWithKeyUsage(t *testing.T, keyUsage x509.KeyUsage) (*x509.Certi
 		t.Fatal(err)
 	}
 	return cert, key
-}
-
-// GenerateSubjectKeyID generates SubjectKeyId used in Certificate
-// ID is 160-bit SHA-1 hash of the value of the BIT STRING subjectPublicKey
-func generateSubjectKeyID(pub crypto.PublicKey) ([]byte, error) {
-	var pubBytes []byte
-	var err error
-	switch pub := pub.(type) {
-	case *rsa.PublicKey:
-		pubBytes, err = asn1.Marshal(rsaPublicKey{
-			N: pub.N,
-			E: pub.E,
-		})
-		if err != nil {
-			return nil, err
-		}
-	default:
-		return nil, errors.New("only RSA public key is supported")
-	}
-
-	hash := sha1.Sum(pubBytes)
-
-	return hash[:], nil
 }
 
 func loadCACredentials(t *testing.T) (*x509.Certificate, *rsa.PrivateKey) {


### PR DESCRIPTION
This PR is to solve issue #123.

Copying the issue description here to save readers' time.
------
Currently, the CSR sent in a PKCSReq message is encrypted with all the certificates returned from GetCaCert operation.
https://github.com/micromdm/scep/blob/f3adbb75202bf4f4f244e05be4f315f708bb75b0/scep/scep.go#L448
A windows SCEP server may not just return the CA certificate, but also NDES certificates. Some of these certificates are not created with KeyEncipherment KeyUsage. Some of them are only for Digital Signature purposes. Adding these certificates as recipients for the encrypted messages introduces decryption errors from the server's side.

The proposal here is to filter the certificates received from GetCaCert by KeyUsage, particularly KeyEncipherment, and use only those as the encrypted content recipients.