### PR TITLE
Remove crypto/sha1 usage

### DIFF
--- a/cmd/scepserver/scepserver.go
+++ b/cmd/scepserver/scepserver.go
@@ -4,7 +4,7 @@ import (
 	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
-	"crypto/sha1"
+	"crypto/sha256"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/asn1"
@@ -342,7 +342,7 @@ func generateSubjectKeyID(pub crypto.PublicKey) ([]byte, error) {
 		return nil, errors.New("only RSA public key is supported")
 	}
 
-	hash := sha1.Sum(pubBytes)
+	hash := sha256.Sum256(pubBytes)
 
 	return hash[:], nil
 }

--- a/crypto/x509util/x509util.go
+++ b/crypto/x509util/x509util.go
@@ -35,7 +35,6 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rsa"
-	_ "crypto/sha1"
 	_ "crypto/sha256"
 	_ "crypto/sha512"
 	"crypto/x509"

--- a/depot/bolt/depot.go
+++ b/depot/bolt/depot.go
@@ -5,7 +5,7 @@ import (
 	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
-	"crypto/sha1"
+	"crypto/sha256"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/asn1"
@@ -334,7 +334,7 @@ func generateSubjectKeyID(pub crypto.PublicKey) ([]byte, error) {
 		return nil, errors.New("only RSA public key is supported")
 	}
 
-	hash := sha1.Sum(pubBytes)
+	hash := sha256.Sum256(pubBytes)
 
 	return hash[:], nil
 }

--- a/depot/signer.go
+++ b/depot/signer.go
@@ -4,7 +4,7 @@ import (
 	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
-	"crypto/sha1"
+	"crypto/sha256"
 	"crypto/x509"
 	"encoding/asn1"
 	"errors"
@@ -110,7 +110,7 @@ func generateSubjectKeyID(pub crypto.PublicKey) ([]byte, error) {
 		return nil, errors.New("only RSA public key is supported")
 	}
 
-	hash := sha1.Sum(pubBytes)
+	hash := sha256.Sum256(pubBytes)
 
 	return hash[:], nil
 }

--- a/scep/scep.go
+++ b/scep/scep.go
@@ -10,7 +10,7 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
-	"crypto/sha1"
+	"crypto/sha256"
 	"crypto/x509"
 	"encoding/asn1"
 	"encoding/base64"
@@ -673,7 +673,7 @@ func generateSubjectKeyID(pub crypto.PublicKey) ([]byte, error) {
 		return nil, errors.New("only ECDSA and RSA public keys are supported")
 	}
 
-	hash := sha1.Sum(pubBytes)
+	hash := sha256.Sum256(pubBytes)
 
 	return hash[:], nil
 }

--- a/scep/scep_test.go
+++ b/scep/scep_test.go
@@ -4,7 +4,7 @@ import (
 	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
-	"crypto/sha1"
+	"crypto/sha256"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/asn1"
@@ -310,7 +310,7 @@ func GenerateSubjectKeyID(pub crypto.PublicKey) ([]byte, error) {
 		return nil, errors.New("only RSA public key is supported")
 	}
 
-	hash := sha1.Sum(pubBytes)
+	hash := sha256.Sum256(pubBytes)
 
 	return hash[:], nil
 }


### PR DESCRIPTION
As mentioned in [crypto docs](https://golang.org/pkg/crypto/sha1/).

> SHA-1 is cryptographically broken and should not be used for secure applications.

This PR removes the usage of crypto/sha1 package from all micromdm/scep targets.