### PR TITLE
Fall-back to to using non-filtered certs

### DIFF
--- a/scep/scep.go
+++ b/scep/scep.go
@@ -554,7 +554,8 @@ func NewCSRRequest(csr *x509.CertificateRequest, tmpl *PKIMessage, opts ...Optio
 	derBytes := csr.Raw
 	recipients := filterCertificatesByKeyUsage(tmpl.Recipients, x509.KeyUsageKeyEncipherment)
 	if len(recipients) == 0 {
-		return nil, errors.New("no recipients that can be used for KeyEncipherment.")
+		// fall back to using non-filtered certs
+		recipients = tmpl.Recipients
 	}
 	e7, err := pkcs7.Encrypt(derBytes, recipients)
 	if err != nil {

--- a/scep/scep_test.go
+++ b/scep/scep_test.go
@@ -134,7 +134,7 @@ func TestNewCSRRequest(t *testing.T) {
 		keyUsage        x509.KeyUsage
 		shouldCreateCSR bool
 	}{
-		{"KeyEncipherment not set", x509.KeyUsageDigitalSignature, false},
+		{"KeyEncipherment not set", x509.KeyUsageDigitalSignature, true},
 		{"KeyEncipherment is set", x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature, true},
 	} {
 		test := test


### PR DESCRIPTION
The changes in #136 mean that for those CA certs that do not have KeyEncipherment get excluded. Which if those are the only ones available.. is a problem. :) This PR falls-back to the previous behavior.