### PR TITLE
Use Content-Type: application/octet-stream for POST PKIOperation

### DIFF
--- a/server/transport.go
+++ b/server/transport.go
@@ -60,6 +60,7 @@ func EncodeSCEPRequest(ctx context.Context, r *http.Request, request interface{}
 		u := r.URL
 		u.RawQuery = params.Encode()
 		rr, err := http.NewRequest("POST", u.String(), body)
+		rr.Header.Set("Content-Type", "application/octet-stream")
 		if err != nil {
 			return errors.Wrapf(err, "creating new POST request for %s", req.Operation)
 		}


### PR DESCRIPTION
[SCEP-23 Appendix-F](https://tools.ietf.org/html/draft-nourse-scep-23#appendix-F) omits the inclusion of a Content-Type. However I know of at least one commercial SCEP server that depends on using a Content-Type and I believe Apple SCEP clients also set a Content-Type header. Open to discussion, of course.