### PR TITLE
Add CertsSelector option

### DIFF
--- a/scep/certs_selector.go
+++ b/scep/certs_selector.go
@@ -1,0 +1,30 @@
+package scep
+
+import "crypto/x509"
+
+// A CertsSelector filters certificates.
+type CertsSelector interface {
+	SelectCerts([]*x509.Certificate) []*x509.Certificate
+}
+
+// NopCertsSelector is a CertsSelector that does not do anything.
+type NopCertsSelector struct{}
+
+func (s NopCertsSelector) SelectCerts(certs []*x509.Certificate) []*x509.Certificate {
+	return certs
+}
+
+// A EnciphermentCertsSelector is a CertsSelector that selects
+// certificates eligible for key encipherment. This selector can be used
+// to filter PKCSReq recipients.
+type EnciphermentCertsSelector struct{}
+
+func (s EnciphermentCertsSelector) SelectCerts(certs []*x509.Certificate) (selected []*x509.Certificate) {
+	enciphermentKeyUsages := x509.KeyUsageKeyEncipherment | x509.KeyUsageDataEncipherment
+	for _, cert := range certs {
+		if cert.KeyUsage&enciphermentKeyUsages != 0 {
+			selected = append(selected, cert)
+		}
+	}
+	return selected
+}

--- a/scep/certs_selector.go
+++ b/scep/certs_selector.go
@@ -2,6 +2,11 @@ package scep
 
 import "crypto/x509"
 
+// A CertsSelector filters certificates.
+type CertsSelector interface {
+	SelectCerts([]*x509.Certificate) []*x509.Certificate
+}
+
 // CertsSelectorFunc is a type of function that filters certificates.
 type CertsSelectorFunc func([]*x509.Certificate) []*x509.Certificate
 
@@ -17,7 +22,7 @@ func NopCertsSelector() CertsSelectorFunc {
 }
 
 // A EnciphermentCertsSelector returns a CertsSelectorFunc that selects
-// certificates eligible for key encipherment. This certsSelectorFunc can be used
+// certificates eligible for key encipherment. This certsSelector can be used
 // to filter PKCSReq recipients.
 func EnciphermentCertsSelector() CertsSelectorFunc {
 	return func(certs []*x509.Certificate) (selected []*x509.Certificate) {

--- a/scep/certs_selector.go
+++ b/scep/certs_selector.go
@@ -2,29 +2,31 @@ package scep
 
 import "crypto/x509"
 
-// A CertsSelector filters certificates.
-type CertsSelector interface {
-	SelectCerts([]*x509.Certificate) []*x509.Certificate
+// CertsSelectorFunc is a type of function that filters certificates.
+type CertsSelectorFunc func([]*x509.Certificate) []*x509.Certificate
+
+func (f CertsSelectorFunc) SelectCerts(certs []*x509.Certificate) []*x509.Certificate {
+	return f(certs)
 }
 
-// NopCertsSelector is a CertsSelector that does not do anything.
-type NopCertsSelector struct{}
-
-func (s NopCertsSelector) SelectCerts(certs []*x509.Certificate) []*x509.Certificate {
-	return certs
-}
-
-// A EnciphermentCertsSelector is a CertsSelector that selects
-// certificates eligible for key encipherment. This selector can be used
-// to filter PKCSReq recipients.
-type EnciphermentCertsSelector struct{}
-
-func (s EnciphermentCertsSelector) SelectCerts(certs []*x509.Certificate) (selected []*x509.Certificate) {
-	enciphermentKeyUsages := x509.KeyUsageKeyEncipherment | x509.KeyUsageDataEncipherment
-	for _, cert := range certs {
-		if cert.KeyUsage&enciphermentKeyUsages != 0 {
-			selected = append(selected, cert)
-		}
+// NopCertsSelector returns a CertsSelectorFunc that does not do anything.
+func NopCertsSelector() CertsSelectorFunc {
+	return func(certs []*x509.Certificate) []*x509.Certificate {
+		return certs
 	}
-	return selected
+}
+
+// A EnciphermentCertsSelector returns a CertsSelectorFunc that selects
+// certificates eligible for key encipherment. This certsSelectorFunc can be used
+// to filter PKCSReq recipients.
+func EnciphermentCertsSelector() CertsSelectorFunc {
+	return func(certs []*x509.Certificate) (selected []*x509.Certificate) {
+		enciphermentKeyUsages := x509.KeyUsageKeyEncipherment | x509.KeyUsageDataEncipherment
+		for _, cert := range certs {
+			if cert.KeyUsage&enciphermentKeyUsages != 0 {
+				selected = append(selected, cert)
+			}
+		}
+		return selected
+	}
 }

--- a/scep/certs_selector_test.go
+++ b/scep/certs_selector_test.go
@@ -36,7 +36,7 @@ func TestEnciphermentCertsSelector(t *testing.T) {
 		t.Run(test.testName, func(t *testing.T) {
 			t.Parallel()
 
-			selected := EnciphermentCertsSelector{}.SelectCerts(test.certs)
+			selected := EnciphermentCertsSelector().SelectCerts(test.certs)
 			if !certsKeyUsagesEq(selected, test.expectedSelectedCerts) {
 				t.Fatal("selected and expected certificates did not match")
 			}
@@ -77,7 +77,7 @@ func TestNopCertsSelector(t *testing.T) {
 		t.Run(test.testName, func(t *testing.T) {
 			t.Parallel()
 
-			selected := NopCertsSelector{}.SelectCerts(test.certs)
+			selected := NopCertsSelector().SelectCerts(test.certs)
 			if !certsKeyUsagesEq(selected, test.expectedSelectedCerts) {
 				t.Fatal("selected and expected certificates did not match")
 			}

--- a/scep/certs_selector_test.go
+++ b/scep/certs_selector_test.go
@@ -1,0 +1,100 @@
+package scep
+
+import (
+	"crypto/x509"
+	"testing"
+)
+
+func TestEnciphermentCertsSelector(t *testing.T) {
+	for _, test := range []struct {
+		testName              string
+		certs                 []*x509.Certificate
+		expectedSelectedCerts []*x509.Certificate
+	}{
+		{
+			"empty certificates list",
+			[]*x509.Certificate{},
+			[]*x509.Certificate{},
+		},
+		{
+			"non-empty certificates list",
+			[]*x509.Certificate{
+				{KeyUsage: x509.KeyUsageKeyEncipherment},
+				{KeyUsage: x509.KeyUsageDataEncipherment},
+				{KeyUsage: x509.KeyUsageKeyEncipherment | x509.KeyUsageDataEncipherment},
+				{KeyUsage: x509.KeyUsageDigitalSignature},
+				{},
+			},
+			[]*x509.Certificate{
+				{KeyUsage: x509.KeyUsageKeyEncipherment},
+				{KeyUsage: x509.KeyUsageDataEncipherment},
+				{KeyUsage: x509.KeyUsageKeyEncipherment | x509.KeyUsageDataEncipherment},
+			},
+		},
+	} {
+		test := test
+		t.Run(test.testName, func(t *testing.T) {
+			t.Parallel()
+
+			selected := EnciphermentCertsSelector{}.SelectCerts(test.certs)
+			if !certsKeyUsagesEq(selected, test.expectedSelectedCerts) {
+				t.Fatal("selected and expected certificates did not match")
+			}
+		})
+	}
+}
+
+func TestNopCertsSelector(t *testing.T) {
+	for _, test := range []struct {
+		testName              string
+		certs                 []*x509.Certificate
+		expectedSelectedCerts []*x509.Certificate
+	}{
+		{
+			"empty certificates list",
+			[]*x509.Certificate{},
+			[]*x509.Certificate{},
+		},
+		{
+			"non-empty certificates list",
+			[]*x509.Certificate{
+				{KeyUsage: x509.KeyUsageKeyEncipherment},
+				{KeyUsage: x509.KeyUsageDataEncipherment},
+				{KeyUsage: x509.KeyUsageKeyEncipherment | x509.KeyUsageDataEncipherment},
+				{KeyUsage: x509.KeyUsageDigitalSignature},
+				{},
+			},
+			[]*x509.Certificate{
+				{KeyUsage: x509.KeyUsageKeyEncipherment},
+				{KeyUsage: x509.KeyUsageDataEncipherment},
+				{KeyUsage: x509.KeyUsageKeyEncipherment | x509.KeyUsageDataEncipherment},
+				{KeyUsage: x509.KeyUsageDigitalSignature},
+				{},
+			},
+		},
+	} {
+		test := test
+		t.Run(test.testName, func(t *testing.T) {
+			t.Parallel()
+
+			selected := NopCertsSelector{}.SelectCerts(test.certs)
+			if !certsKeyUsagesEq(selected, test.expectedSelectedCerts) {
+				t.Fatal("selected and expected certificates did not match")
+			}
+		})
+	}
+}
+
+// certsKeyUsagesEq returns true if certs in a have the same key usages
+// of certs in b and in the same order.
+func certsKeyUsagesEq(a []*x509.Certificate, b []*x509.Certificate) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i, cert := range a {
+		if cert.KeyUsage != b[i].KeyUsage {
+			return false
+		}
+	}
+	return true
+}

--- a/scep/scep.go
+++ b/scep/scep.go
@@ -152,14 +152,14 @@ func WithCACerts(caCerts []*x509.Certificate) Option {
 	}
 }
 
-// WithCertsSelector adds the certificates certsSelectorFunc option to the SCEP
+// WithCertsSelector adds the certificates certsSelector option to the SCEP
 // operations.
 // This option is effective when used with NewCSRRequest function. In
-// this case, only certificates selected with the certsSelectorFunc will be used
+// this case, only certificates selected with the certsSelector will be used
 // as the PKCS #7 message recipients.
-func WithCertsSelector(selector CertsSelectorFunc) Option {
+func WithCertsSelector(selector CertsSelector) Option {
 	return func(c *config) {
-		c.certsSelectorFunc = selector
+		c.certsSelector = selector
 	}
 }
 
@@ -167,9 +167,9 @@ func WithCertsSelector(selector CertsSelectorFunc) Option {
 type Option func(*config)
 
 type config struct {
-	logger            log.Logger
-	caCerts           []*x509.Certificate // specified if CA certificates have already been retrieved
-	certsSelectorFunc CertsSelectorFunc
+	logger        log.Logger
+	caCerts       []*x509.Certificate // specified if CA certificates have already been retrieved
+	certsSelector CertsSelector
 }
 
 // PKIMessage defines the possible SCEP message types
@@ -558,13 +558,13 @@ func CACerts(data []byte) ([]*x509.Certificate, error) {
 
 // NewCSRRequest creates a scep PKI PKCSReq/UpdateReq message
 func NewCSRRequest(csr *x509.CertificateRequest, tmpl *PKIMessage, opts ...Option) (*PKIMessage, error) {
-	conf := &config{logger: log.NewNopLogger(), certsSelectorFunc: NopCertsSelector()}
+	conf := &config{logger: log.NewNopLogger(), certsSelector: NopCertsSelector()}
 	for _, opt := range opts {
 		opt(conf)
 	}
 
 	derBytes := csr.Raw
-	recipients := conf.certsSelectorFunc.SelectCerts(tmpl.Recipients)
+	recipients := conf.certsSelector.SelectCerts(tmpl.Recipients)
 	if len(recipients) == 0 {
 		return nil, errors.New("no recipients that can be used for KeyEncipherment.")
 	}

--- a/scep/scep_test.go
+++ b/scep/scep_test.go
@@ -136,25 +136,25 @@ func TestNewCSRRequest(t *testing.T) {
 		shouldCreateCSR   bool
 	}{
 		{
-			"KeyEncipherment not set with NOP certificates certsSelectorFunc",
+			"KeyEncipherment not set with NOP certificates selector",
 			x509.KeyUsageCertSign,
 			scep.NopCertsSelector(),
 			true,
 		},
 		{
-			"KeyEncipherment is set with NOP certificates certsSelectorFunc",
+			"KeyEncipherment is set with NOP certificates selector",
 			x509.KeyUsageCertSign | x509.KeyUsageKeyEncipherment,
 			scep.NopCertsSelector(),
 			true,
 		},
 		{
-			"KeyEncipherment not set with Encipherment certificates certsSelectorFunc",
+			"KeyEncipherment not set with Encipherment certificates selector",
 			x509.KeyUsageCertSign,
 			scep.EnciphermentCertsSelector(),
 			false,
 		},
 		{
-			"KeyEncipherment is set with Encipherment certificates certsSelectorFunc",
+			"KeyEncipherment is set with Encipherment certificates selector",
 			x509.KeyUsageCertSign | x509.KeyUsageKeyEncipherment,
 			scep.EnciphermentCertsSelector(),
 			true,

--- a/scep/scep_test.go
+++ b/scep/scep_test.go
@@ -130,33 +130,33 @@ func TestSignCSR(t *testing.T) {
 
 func TestNewCSRRequest(t *testing.T) {
 	for _, test := range []struct {
-		testName        string
-		keyUsage        x509.KeyUsage
-		selector        scep.CertsSelector
-		shouldCreateCSR bool
+		testName          string
+		keyUsage          x509.KeyUsage
+		certsSelectorFunc scep.CertsSelectorFunc
+		shouldCreateCSR   bool
 	}{
 		{
-			"KeyEncipherment not set with NOP certificates selector",
+			"KeyEncipherment not set with NOP certificates certsSelectorFunc",
 			x509.KeyUsageCertSign,
-			scep.NopCertsSelector{},
+			scep.NopCertsSelector(),
 			true,
 		},
 		{
-			"KeyEncipherment is set with NOP certificates selector",
+			"KeyEncipherment is set with NOP certificates certsSelectorFunc",
 			x509.KeyUsageCertSign | x509.KeyUsageKeyEncipherment,
-			scep.NopCertsSelector{},
+			scep.NopCertsSelector(),
 			true,
 		},
 		{
-			"KeyEncipherment not set with Encipherment certificates selector",
+			"KeyEncipherment not set with Encipherment certificates certsSelectorFunc",
 			x509.KeyUsageCertSign,
-			scep.EnciphermentCertsSelector{},
+			scep.EnciphermentCertsSelector(),
 			false,
 		},
 		{
-			"KeyEncipherment is set with Encipherment certificates selector",
+			"KeyEncipherment is set with Encipherment certificates certsSelectorFunc",
 			x509.KeyUsageCertSign | x509.KeyUsageKeyEncipherment,
-			scep.EnciphermentCertsSelector{},
+			scep.EnciphermentCertsSelector(),
 			true,
 		},
 	} {
@@ -184,7 +184,7 @@ func TestNewCSRRequest(t *testing.T) {
 				SignerKey:   clientkey,
 			}
 
-			pkcsreq, err := scep.NewCSRRequest(csr, tmpl, scep.WithCertsSelector(test.selector))
+			pkcsreq, err := scep.NewCSRRequest(csr, tmpl, scep.WithCertsSelector(test.certsSelectorFunc))
 			if test.shouldCreateCSR && err != nil {
 				t.Fatalf("keyUsage: %d, failed creating a CSR request: %v", test.keyUsage, err)
 			}

--- a/scep/scep_test.go
+++ b/scep/scep_test.go
@@ -132,10 +132,33 @@ func TestNewCSRRequest(t *testing.T) {
 	for _, test := range []struct {
 		testName        string
 		keyUsage        x509.KeyUsage
+		selector        scep.CertsSelector
 		shouldCreateCSR bool
 	}{
-		{"KeyEncipherment not set", x509.KeyUsageDigitalSignature, false},
-		{"KeyEncipherment is set", x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature, true},
+		{
+			"KeyEncipherment not set with NOP certificates selector",
+			x509.KeyUsageCertSign,
+			scep.NopCertsSelector{},
+			true,
+		},
+		{
+			"KeyEncipherment is set with NOP certificates selector",
+			x509.KeyUsageCertSign | x509.KeyUsageKeyEncipherment,
+			scep.NopCertsSelector{},
+			true,
+		},
+		{
+			"KeyEncipherment not set with Encipherment certificates selector",
+			x509.KeyUsageCertSign,
+			scep.EnciphermentCertsSelector{},
+			false,
+		},
+		{
+			"KeyEncipherment is set with Encipherment certificates selector",
+			x509.KeyUsageCertSign | x509.KeyUsageKeyEncipherment,
+			scep.EnciphermentCertsSelector{},
+			true,
+		},
 	} {
 		test := test
 		t.Run(test.testName, func(t *testing.T) {
@@ -161,7 +184,7 @@ func TestNewCSRRequest(t *testing.T) {
 				SignerKey:   clientkey,
 			}
 
-			pkcsreq, err := scep.NewCSRRequest(csr, tmpl)
+			pkcsreq, err := scep.NewCSRRequest(csr, tmpl, scep.WithCertsSelector(test.selector))
 			if test.shouldCreateCSR && err != nil {
 				t.Fatalf("keyUsage: %d, failed creating a CSR request: %v", test.keyUsage, err)
 			}


### PR DESCRIPTION
As mentioned in #145, some CAs don't have `KeyUsageKeyEncipherment` key usage set in their certificates. This PR introduces `CertsSelector` which should make it easier for clients that want to enforce a custom criteria on how to filter certificates.