### PR TITLE
CSRSigner cleanup

### DIFF
--- a/challenge/challenge_bolt_test.go
+++ b/challenge/challenge_bolt_test.go
@@ -1,7 +1,6 @@
 package challenge
 
 import (
-	"crypto/x509"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -63,11 +62,7 @@ func TestDynamicChallenge(t *testing.T) {
 	}
 
 	// test CSRSigner middleware
-	nullSigner := scepserver.CSRSignerFunc(func(*scep.CSRReqMessage) (*x509.Certificate, error) {
-		return nil, nil
-	})
-	mw := NewCSRSignerMiddleware(depot)
-	signer := mw(nullSigner)
+	signer := Middleware(depot, scepserver.NopCSRSigner())
 
 	csrReq := &scep.CSRReqMessage{
 		ChallengePassword: challengePassword,

--- a/server/csrsigner.go
+++ b/server/csrsigner.go
@@ -1,0 +1,44 @@
+package scepserver
+
+import (
+	"crypto/subtle"
+	"crypto/x509"
+	"errors"
+
+	"github.com/micromdm/scep/scep"
+)
+
+// CSRSigner is a handler for CSR signing by the CA/RA
+//
+// SignCSR should take the CSR in the CSRReqMessage and return a
+// Certificate signed by the CA.
+type CSRSigner interface {
+	SignCSR(*scep.CSRReqMessage) (*x509.Certificate, error)
+}
+
+// CSRSignerFunc is an adapter for CSR signing by the CA/RA
+type CSRSignerFunc func(*scep.CSRReqMessage) (*x509.Certificate, error)
+
+// SignCSR calls f(m)
+func (f CSRSignerFunc) SignCSR(m *scep.CSRReqMessage) (*x509.Certificate, error) {
+	return f(m)
+}
+
+// NopCSRSigner does nothing
+func NopCSRSigner() CSRSignerFunc {
+	return func(m *scep.CSRReqMessage) (*x509.Certificate, error) {
+		return nil, nil
+	}
+}
+
+// ChallengeMiddleware wraps next in a CSRSigner that validates the challenge from the CSR
+func ChallengeMiddleware(challenge string, next CSRSigner) CSRSignerFunc {
+	challengeBytes := []byte(challenge)
+	return func(m *scep.CSRReqMessage) (*x509.Certificate, error) {
+		// TODO: compare challenge only for PKCSReq?
+		if subtle.ConstantTimeCompare(challengeBytes, []byte(m.ChallengePassword)) != 1 {
+			return nil, errors.New("invalid challenge")
+		}
+		return next.SignCSR(m)
+	}
+}

--- a/server/csrsigner_test.go
+++ b/server/csrsigner_test.go
@@ -1,0 +1,26 @@
+package scepserver
+
+import (
+	"testing"
+
+	"github.com/micromdm/scep/scep"
+)
+
+func TestChallengeMiddleware(t *testing.T) {
+	testPW := "RIGHT"
+	signer := ChallengeMiddleware(testPW, NopCSRSigner())
+
+	csrReq := &scep.CSRReqMessage{ChallengePassword: testPW}
+
+	_, err := signer.SignCSR(csrReq)
+	if err != nil {
+		t.Error(err)
+	}
+
+	csrReq.ChallengePassword = "WRONG"
+
+	_, err = signer.SignCSR(csrReq)
+	if err == nil {
+		t.Error("invalid challenge should generate an error")
+	}
+}


### PR DESCRIPTION
- Move `CSRSigner` and pals to new file.
- Add a test for the (static) challenge verifier.
- Change challenge verifier to use `subtle.ConstantTimeCompare()` rather than string compare.
- Rename most `Middleware` adapters. Their containing package gives them context.
- Remove the `.WithCSRSignerMiddleware()` adapter/middleware as a `ServiceOption`. Too verbose and abstracted. Instead just wrap the `CSRSigner`s directly.
- Error consistency.
- Create `NopCSRSigner()` (for testing).
- Sort imports: stdlib, project, external.