### PR TITLE
Create Depot signer struct with Options

### DIFF
--- a/cmd/scepserver/scepserver.go
+++ b/cmd/scepserver/scepserver.go
@@ -130,7 +130,12 @@ func main() {
 			lginfo.Log("err", "missing CA certificate")
 			os.Exit(1)
 		}
-		signer := scepdepot.CSRSigner(depot, allowRenewal, clientValidity, *flCAPass)
+		var signer scepserver.CSRSigner = scepdepot.NewSigner(
+			depot,
+			scepdepot.WithAllowRenewalDays(allowRenewal),
+			scepdepot.WithValidityDays(clientValidity),
+			scepdepot.WithCAPass(*flCAPass),
+		)
 		if *flChallengePassword != "" {
 			signer = scepserver.ChallengeMiddleware(*flChallengePassword, signer)
 		}

--- a/server/service_bolt_test.go
+++ b/server/service_bolt_test.go
@@ -45,7 +45,7 @@ func TestCaCert(t *testing.T) {
 	caCert := certs[0]
 
 	// SCEP service
-	svc, err := scepserver.NewService(caCert, key, scepdepot.CSRSigner(depot, 14, 365, ""))
+	svc, err := scepserver.NewService(caCert, key, scepdepot.NewSigner(depot))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Depot signer was just a `CSRSignerFunc`. Which worked but its flexibility was limited. Turn it into a real Go struct with associated Options. My hope is that this makes it easier for folks to integrate things like additional attributes for issues like #103 and #91.