### PR TITLE
Support message with GetCACert call

### DIFF
--- a/cmd/scepclient/scepclient.go
+++ b/cmd/scepclient/scepclient.go
@@ -104,7 +104,7 @@ func run(cfg runCfg) error {
 		self = s
 	}
 
-	resp, certNum, err := client.GetCACert(ctx)
+	resp, certNum, err := client.GetCACert(ctx, "")
 	if err != nil {
 		return err
 	}

--- a/cmd/scepclient/scepclient.go
+++ b/cmd/scepclient/scepclient.go
@@ -45,6 +45,7 @@ type runCfg struct {
 	caMD5        string
 	debug        bool
 	logfmt       string
+	caCertMsg    string
 }
 
 func run(cfg runCfg) error {
@@ -104,7 +105,7 @@ func run(cfg runCfg) error {
 		self = s
 	}
 
-	resp, certNum, err := client.GetCACert(ctx, "")
+	resp, certNum, err := client.GetCACert(ctx, cfg.caCertMsg)
 	if err != nil {
 		return err
 	}
@@ -264,6 +265,7 @@ func main() {
 		flLoc               = flag.String("locality", "", "locality for certificate")
 		flProvince          = flag.String("province", "", "province for certificate")
 		flCountry           = flag.String("country", "US", "country code in certificate")
+		flCACertMessage     = flag.String("cacert-message", "", "message sent with GetCACert operation")
 
 		// in case of multiple certificate authorities, we need to figure out who the recipient of the encrypted
 		// data is.
@@ -315,6 +317,7 @@ func main() {
 		caMD5:        *flCAFingerprint,
 		debug:        *flDebugLogging,
 		logfmt:       logfmt,
+		caCertMsg:    *flCACertMessage,
 	}
 
 	if err := run(cfg); err != nil {

--- a/server/endpoint.go
+++ b/server/endpoint.go
@@ -57,8 +57,8 @@ func (e *Endpoints) Supports(cap string) bool {
 	return bytes.Contains(e.capabilities, []byte(cap))
 }
 
-func (e *Endpoints) GetCACert(ctx context.Context) ([]byte, int, error) {
-	request := SCEPRequest{Operation: getCACert}
+func (e *Endpoints) GetCACert(ctx context.Context, message string) ([]byte, int, error) {
+	request := SCEPRequest{Operation: getCACert, Message: []byte(message)}
 	response, err := e.GetEndpoint(ctx, request)
 	if err != nil {
 		return nil, 0, err
@@ -140,7 +140,7 @@ func MakeSCEPEndpoint(svc Service) endpoint.Endpoint {
 		case "GetCACaps":
 			resp.Data, resp.Err = svc.GetCACaps(ctx)
 		case "GetCACert":
-			resp.Data, resp.CACertNum, resp.Err = svc.GetCACert(ctx)
+			resp.Data, resp.CACertNum, resp.Err = svc.GetCACert(ctx, string(req.Message))
 		case "PKIOperation":
 			resp.Data, resp.Err = svc.PKIOperation(ctx, req.Message)
 		default:

--- a/server/service.go
+++ b/server/service.go
@@ -20,7 +20,8 @@ type Service interface {
 	// GetCACert returns CA certificate or
 	// a CA certificate chain with intermediates
 	// in a PKCS#7 Degenerate Certificates format
-	GetCACert(ctx context.Context) ([]byte, int, error)
+	// message is an optional string for the CA
+	GetCACert(ctx context.Context, message string) ([]byte, int, error)
 
 	// PKIOperation handles incoming SCEP messages such as PKCSReq and
 	// sends back a CertRep PKIMessag.
@@ -57,7 +58,7 @@ func (svc *service) GetCACaps(ctx context.Context) ([]byte, error) {
 	return defaultCaps, nil
 }
 
-func (svc *service) GetCACert(ctx context.Context) ([]byte, int, error) {
+func (svc *service) GetCACert(ctx context.Context, _ string) ([]byte, int, error) {
 	if svc.crt == nil {
 		return nil, 0, errors.New("missing CA certificate")
 	}

--- a/server/service_bolt_test.go
+++ b/server/service_bolt_test.go
@@ -75,7 +75,7 @@ func TestCaCert(t *testing.T) {
 	ctx := context.Background()
 	for i := 0; i < 5; i++ {
 		// check CA
-		caBytes, num, err := svc.GetCACert(ctx)
+		caBytes, num, err := svc.GetCACert(ctx, "")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/server/service_logging.go
+++ b/server/service_logging.go
@@ -29,15 +29,16 @@ func (mw *loggingService) GetCACaps(ctx context.Context) (caps []byte, err error
 	return
 }
 
-func (mw *loggingService) GetCACert(ctx context.Context) (cert []byte, certNum int, err error) {
+func (mw *loggingService) GetCACert(ctx context.Context, message string) (cert []byte, certNum int, err error) {
 	defer func(begin time.Time) {
 		_ = mw.logger.Log(
 			"method", "GetCACert",
+			"message", message,
 			"err", err,
 			"took", time.Since(begin),
 		)
 	}(time.Now())
-	cert, certNum, err = mw.Service.GetCACert(ctx)
+	cert, certNum, err = mw.Service.GetCACert(ctx, message)
 	return
 }
 

--- a/server/transport.go
+++ b/server/transport.go
@@ -48,7 +48,12 @@ func EncodeSCEPRequest(ctx context.Context, r *http.Request, request interface{}
 	switch r.Method {
 	case "GET":
 		if len(req.Message) > 0 {
-			msg := base64.URLEncoding.EncodeToString(req.Message)
+			var msg string
+			if req.Operation == "PKIOperation" {
+				msg = base64.URLEncoding.EncodeToString(req.Message)
+			} else {
+				msg = string(req.Message)
+			}
 			params.Set("message", msg)
 		}
 		r.URL.RawQuery = params.Encode()


### PR DESCRIPTION
[SCEP-23 § 5.2.1](https://tools.ietf.org/html/draft-nourse-scep-23#section-5.2.1) **GetCACert** says

> The MESSAGE MAY be omitted, or it MAY be a string that represents the certification authority issuer identifier.  A CA Administrator defined string allows for multiple CAs supported by one SCEP server.

Allow passing this through to a SCEP server. Our server doesn't do anything with it at the moment, but support its use on the client-side.