### PR TITLE
Debug log CA certs and hashes in scepclient

### DIFF
--- a/cmd/scepclient/scepclient.go
+++ b/cmd/scepclient/scepclient.go
@@ -127,7 +127,7 @@ func run(cfg runCfg) error {
 	}
 
 	if cfg.debug {
-		debugCerts(logger, certs)
+		debugCerts(level.Debug(logger), certs)
 	}
 
 	var signerCert *x509.Certificate
@@ -227,13 +227,12 @@ func run(cfg runCfg) error {
 
 // debugCerts logs certs and their hashes
 func debugCerts(logger log.Logger, certs []*x509.Certificate) {
-	lgdebug := level.Debug(logger)
-	lgdebug.Log("msg", "certs", "count", len(certs))
+	logger.Log("msg", "cacertlist", "count", len(certs))
 	for i, cert := range certs {
 		h := sha256.New()
 		h.Write(cert.Raw)
-		lgdebug.Log(
-			"msg", "certs",
+		logger.Log(
+			"msg", "cacertlist",
 			"number", i,
 			"rdn", cert.Subject.ToRDNSequence().String(),
 			"sha256", fmt.Sprintf("%x", h.Sum(nil)),

--- a/cmd/scepclient/scepclient.go
+++ b/cmd/scepclient/scepclient.go
@@ -127,7 +127,7 @@ func run(cfg runCfg) error {
 	}
 
 	if cfg.debug {
-		debugCerts(level.Debug(logger), certs)
+		logCerts(level.Debug(logger), certs)
 	}
 
 	var signerCert *x509.Certificate
@@ -225,8 +225,8 @@ func run(cfg runCfg) error {
 	return nil
 }
 
-// debugCerts logs certs and their hashes
-func debugCerts(logger log.Logger, certs []*x509.Certificate) {
+// logCerts logs the count, number, RDN, and SHA-256 of certs to logger
+func logCerts(logger log.Logger, certs []*x509.Certificate) {
 	logger.Log("msg", "cacertlist", "count", len(certs))
 	for i, cert := range certs {
 		logger.Log(

--- a/cmd/scepclient/scepclient.go
+++ b/cmd/scepclient/scepclient.go
@@ -229,13 +229,11 @@ func run(cfg runCfg) error {
 func debugCerts(logger log.Logger, certs []*x509.Certificate) {
 	logger.Log("msg", "cacertlist", "count", len(certs))
 	for i, cert := range certs {
-		h := sha256.New()
-		h.Write(cert.Raw)
 		logger.Log(
 			"msg", "cacertlist",
 			"number", i,
 			"rdn", cert.Subject.ToRDNSequence().String(),
-			"sha256", fmt.Sprintf("%x", h.Sum(nil)),
+			"sha256", fmt.Sprintf("%x", sha256.Sum256(cert.Raw)),
 		)
 	}
 }


### PR DESCRIPTION
Threw this together in support of #156. It looks like this when logged:

```
ts=2021-03-19T23:30:47.620605Z level=info msg=dumpca idx=0 rdns="OU=SCEP CA,O=scep-ca,C=US" sha256=7b659515f1f2a9c1af5c32e51fcdbeb67adfd4679d7998d0f29c757316cd29b7
```