### PR TITLE
Expect SHA-256 instead of MD5 fingerprint flag value

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ cat - > /tmp/scep.csr
 $ ./scepclient-linux-amd64 -help
 Usage of ./scepclient-linux-amd64:
   -ca-fingerprint string
-    	(Note: Changed from MD5) SHA-256 digest of CA certificate for NDES server.
+    	SHA-256 digest of CA certificate for NDES server. Note: Changed from MD5.
   -certificate string
     	certificate path, if there is no key, scepclient will create one
   -challenge string

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ cat - > /tmp/scep.csr
 $ ./scepclient-linux-amd64 -help
 Usage of ./scepclient-linux-amd64:
   -ca-fingerprint string
-    	md5 fingerprint of CA certificate for NDES server.
+    	(Note: Changed from MD5) SHA-256 digest of CA certificate for NDES server.
   -certificate string
     	certificate path, if there is no key, scepclient will create one
   -challenge string

--- a/cmd/scepclient/scepclient.go
+++ b/cmd/scepclient/scepclient.go
@@ -269,7 +269,7 @@ func main() {
 
 		// in case of multiple certificate authorities, we need to figure out who the recipient of the encrypted
 		// data is.
-		flCAFingerprint = flag.String("ca-fingerprint", "", "(Note: Changed from MD5) SHA-256 digest of CA certificate for NDES server.")
+		flCAFingerprint = flag.String("ca-fingerprint", "", "SHA-256 digest of CA certificate for NDES server. Note: Changed from MD5.")
 
 		flDebugLogging = flag.Bool("debug", false, "enable debug logging")
 		flLogJSON      = flag.Bool("log-json", false, "use JSON for log output")

--- a/cmd/scepclient/scepclient.go
+++ b/cmd/scepclient/scepclient.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"context"
-	"crypto/md5"
+	"crypto/sha256"
 	"crypto/x509"
 	"flag"
 	"fmt"
@@ -41,7 +41,7 @@ type runCfg struct {
 	country      string
 	challenge    string
 	serverURL    string
-	caMD5        string
+	caSHA256     string
 	debug        bool
 	logfmt       string
 	caCertMsg    string
@@ -146,10 +146,10 @@ func run(cfg runCfg) error {
 	}
 
 	var recipients []*x509.Certificate
-	if cfg.caMD5 == "" {
+	if cfg.caSHA256 == "" {
 		recipients = certs
 	} else {
-		r, err := findRecipients(cfg.caMD5, certs)
+		r, err := findRecipients(cfg.caSHA256, certs)
 		if err != nil {
 			return err
 		}
@@ -223,17 +223,18 @@ func run(cfg runCfg) error {
 
 // Determine the correct recipient based on the fingerprint.
 // In case of NDES that is the last certificate in the chain, not the RA cert.
+// Note: this function assumes that the input certs are sorted as a valid chain.
 // Return a full chain starting with the cert that matches the fingerprint.
 func findRecipients(fingerprint string, certs []*x509.Certificate) ([]*x509.Certificate, error) {
 	fingerprint = strings.Join(strings.Split(fingerprint, " "), "")
 	fingerprint = strings.ToLower(fingerprint)
 	for i, cert := range certs {
-		sum := fmt.Sprintf("%x", md5.Sum(cert.Raw))
+		sum := fmt.Sprintf("%x", sha256.Sum256(cert.Raw))
 		if sum == fingerprint {
 			return certs[i-1:], nil
 		}
 	}
-	return nil, errors.Errorf("could not find cert for md5 %s", fingerprint)
+	return nil, errors.Errorf("could not find cert for sha256 fingerprint: %s", fingerprint)
 }
 
 func validateFlags(keyPath, serverURL string) error {
@@ -268,7 +269,7 @@ func main() {
 
 		// in case of multiple certificate authorities, we need to figure out who the recipient of the encrypted
 		// data is.
-		flCAFingerprint = flag.String("ca-fingerprint", "", "md5 fingerprint of CA certificate for NDES server.")
+		flCAFingerprint = flag.String("ca-fingerprint", "", "(Note: Changed from MD5) SHA-256 digest of CA certificate for NDES server.")
 
 		flDebugLogging = flag.Bool("debug", false, "enable debug logging")
 		flLogJSON      = flag.Bool("log-json", false, "use JSON for log output")
@@ -312,7 +313,7 @@ func main() {
 		province:     *flProvince,
 		challenge:    *flChallengePassword,
 		serverURL:    *flServerURL,
-		caMD5:        *flCAFingerprint,
+		caSHA256:     *flCAFingerprint,
 		debug:        *flDebugLogging,
 		logfmt:       logfmt,
 		caCertMsg:    *flCACertMessage,


### PR DESCRIPTION
This PR solves issue #156.

Copying the issue description here to save readers' time.
------
This is to complete pull request #144 which should have removed all weak hash functions usages.

https://github.com/micromdm/scep/blob/c89253406d2e73be69933382e1c0aed9069283be/cmd/scepclient/scepclient.go#L271