### PR TITLE
SHA-256 the raw certificate for its name if no CN

### DIFF
--- a/depot/signer.go
+++ b/depot/signer.go
@@ -2,7 +2,9 @@ package depot
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
 	"crypto/x509"
+	"fmt"
 	"time"
 
 	"github.com/micromdm/scep/cryptoutil"
@@ -120,5 +122,5 @@ func certName(crt *x509.Certificate) string {
 	if crt.Subject.CommonName != "" {
 		return crt.Subject.CommonName
 	}
-	return string(crt.Signature)
+	return fmt.Sprintf("%x", sha256.Sum256(crt.Raw))
 }


### PR DESCRIPTION
Fixes #125.

While I wasn't able to duplicate the issue using a real SCEP client I was able to "force" it by pretending there was no CN to get this issue to surface for me.
