### PR TITLE
Refactor CA cert generation

### DIFF
--- a/depot/cacert.go
+++ b/depot/cacert.go
@@ -1,0 +1,105 @@
+package depot
+
+import (
+	"crypto"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"io"
+	"math/big"
+	"time"
+
+	"github.com/micromdm/scep/v2/cryptoutil"
+)
+
+// CACert represents a new self-signed CA certificate
+type CACert struct {
+	organization       string
+	organizationalUnit string
+	country            string
+	years              int
+}
+
+// NewCACert creates a new CACert object with options
+func NewCACert(opts ...CACertOption) *CACert {
+	c := &CACert{
+		organization:       "scep-ca",
+		organizationalUnit: "SCEP CA",
+		years:              10,
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+type CACertOption func(*CACert)
+
+// WithOrganization specifies the Organization on the CA template.
+func WithOrganization(o string) CACertOption {
+	return func(c *CACert) {
+		c.organization = o
+	}
+}
+
+// WithOrganizationalUnit specifies the OrganizationalUnit on the CA template.
+func WithOrganizationalUnit(ou string) CACertOption {
+	return func(c *CACert) {
+		c.organizationalUnit = ou
+	}
+}
+
+// WithYears specifies the validity date of the CA.
+func WithYears(y int) CACertOption {
+	return func(c *CACert) {
+		c.years = y
+	}
+}
+
+// WithCountry specifies the Country on the CA template.
+func WithCountry(country string) CACertOption {
+	return func(c *CACert) {
+		c.country = country
+	}
+}
+
+// newPkixName creates a new pkix.Name from c
+func (c *CACert) newPkixName() *pkix.Name {
+	return &pkix.Name{
+		Country:            []string{c.country},
+		Organization:       []string{c.organization},
+		OrganizationalUnit: []string{c.organizationalUnit},
+	}
+}
+
+// SelfSign creates an x509 template based off our settings and self-signs it using priv.
+func (c *CACert) SelfSign(rand io.Reader, pub crypto.PublicKey, priv interface{}) ([]byte, error) {
+	subjKeyId, err := cryptoutil.GenerateSubjectKeyID(pub)
+	if err != nil {
+		return nil, err
+	}
+	// Build CA based on RFC5280
+	tmpl := x509.Certificate{
+		Subject:      *c.newPkixName(),
+		SerialNumber: big.NewInt(1),
+
+		// NotBefore is set to be 10min earlier to fix gap on time difference in cluster
+		NotBefore: time.Now().Add(-600).UTC(),
+		NotAfter:  time.Now().AddDate(c.years, 0, 0).UTC(),
+
+		// Used for certificate signing only
+		KeyUsage: x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+
+		// activate CA
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+
+		// Not allow any non-self-issued intermediate CA
+		MaxPathLen: 0,
+
+		// 160-bit SHA-1 hash of the value of the BIT STRING subjectPublicKey
+		// (excluding the tag, length, and number of unused bits)
+		SubjectKeyId: subjKeyId,
+	}
+
+	return x509.CreateCertificate(rand, &tmpl, &tmpl, pub, priv)
+}

--- a/scep/scep_test.go
+++ b/scep/scep_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/micromdm/scep/v2/cryptoutil"
+	"github.com/micromdm/scep/v2/depot"
 	"github.com/micromdm/scep/v2/scep"
 )
 
@@ -242,25 +243,13 @@ func createCaCertWithKeyUsage(t *testing.T, keyUsage x509.KeyUsage) (*x509.Certi
 	if err != nil {
 		t.Fatal(err)
 	}
-	subject := pkix.Name{
-		Country:      []string{"US"},
-		Organization: []string{"MICROMDM"},
-		CommonName:   "MICROMDM SCEP CA",
-	}
-	subjectKeyID, err := cryptoutil.GenerateSubjectKeyID(&key.PublicKey)
-	if err != nil {
-		t.Fatal(err)
-	}
-	authTemplate := x509.Certificate{
-		SerialNumber: big.NewInt(1),
-		Subject:      subject,
-		NotBefore:    time.Now().Add(-600).UTC(),
-		NotAfter:     time.Now().AddDate(1, 0, 0).UTC(),
-		KeyUsage:     keyUsage,
-		IsCA:         true,
-		SubjectKeyId: subjectKeyID,
-	}
-	crtBytes, err := x509.CreateCertificate(rand.Reader, &authTemplate, &authTemplate, &key.PublicKey, key)
+	caCert := depot.NewCACert(
+		depot.WithCountry("US"),
+		depot.WithOrganization("MICROMDM"),
+		depot.WithCommonName("MICROMDM SCEP CA"),
+		depot.WithKeyUsage(keyUsage),
+	)
+	crtBytes, err := caCert.SelfSign(rand.Reader, &key.PublicKey, key)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Move the CA cert generating into the `depot` package. This de-dups the two places where this was happening and sets us up to potentially move all CA-related operations into the `depot` package and/or depot implementations.