### PR TITLE
Fix data races in SignCSR

### DIFF
--- a/depot/signer.go
+++ b/depot/signer.go
@@ -3,6 +3,7 @@ package depot
 import (
 	"crypto/rand"
 	"crypto/x509"
+	"sync"
 	"time"
 
 	"github.com/micromdm/scep/v2/cryptoutil"
@@ -12,6 +13,7 @@ import (
 // Signer signs x509 certificates and stores them in a Depot
 type Signer struct {
 	depot            Depot
+	mu               sync.Mutex
 	caPass           string
 	allowRenewalDays int
 	validityDays     int
@@ -60,6 +62,9 @@ func (s *Signer) SignCSR(m *scep.CSRReqMessage) (*x509.Certificate, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	serial, err := s.depot.Serial()
 	if err != nil {


### PR DESCRIPTION
This addresses the data race problems mentioned #184 by protecting the depot in SignCSR with a mutex. Currently if SignCSR gets overloaded it can break the whole depot by not correctly incrementing the serial (multiple concurrent requests can get the same serial), or checking the CN database can be inconsistent (multiple concurrent requests can cause errors because of concurrent file access or possibly return bad data).

It might be that mutexes could be added to the depot itself, but this could get much more complex without getting many (or any) speed gains. `SignCSR` calls `depot.Serial` near the top, then calls `depot.Put` at the bottom which internally calls `depot.Serial`, and both `depot.Serial` calls should return the same serial, so the serial should be locked for the length of `SignCSR` anyways.