### PR TITLE
added Apple M1 specific release target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ SCEPCLIENT=\
 	scepclient-linux-amd64 \
 	scepclient-linux-arm \
 	scepclient-darwin-amd64 \
+	scepclient-darwin-arm64 \
 	scepclient-freebsd-amd64 \
 	scepclient-windows-amd64.exe
 
@@ -13,6 +14,7 @@ SCEPSERVER=\
 	scepserver-linux-amd64 \
 	scepserver-linux-arm \
 	scepserver-darwin-amd64 \
+	scepserver-darwin-arm64 \
 	scepserver-freebsd-amd64 \
 	scepserver-windows-amd64.exe
 


### PR DESCRIPTION
This is rather cosmetic PR.
Adds ability to build client/server binaries to be used with MacBooks running Apple M1 chip.