### PR TITLE
Sign cert with key usages for server authentication.

### DIFF
--- a/depot/signer.go
+++ b/depot/signer.go
@@ -17,6 +17,7 @@ type Signer struct {
 	caPass           string
 	allowRenewalDays int
 	validityDays     int
+	serverAttrs      bool
 }
 
 // Option customizes Signer
@@ -56,6 +57,12 @@ func WithValidityDays(v int) Option {
 	}
 }
 
+func WithSeverAttrs() Option {
+	return func(s *Signer) {
+		s.serverAttrs = true
+	}
+}
+
 // SignCSR signs a certificate using Signer's Depot CA
 func (s *Signer) SignCSR(m *scep.CSRReqMessage) (*x509.Certificate, error) {
 	id, err := cryptoutil.GenerateSubjectKeyID(m.CSR.PublicKey)
@@ -87,6 +94,11 @@ func (s *Signer) SignCSR(m *scep.CSRReqMessage) (*x509.Certificate, error) {
 		EmailAddresses:     m.CSR.EmailAddresses,
 		IPAddresses:        m.CSR.IPAddresses,
 		URIs:               m.CSR.URIs,
+	}
+
+	if s.serverAttrs {
+		tmpl |= x509.KeyUsageDataEncipherment
+		tmpl.ExtKeyUsage = append(tmpl.ExtKeyUsage, x509.ExtKeyUsageServerAuth)
 	}
 
 	caCerts, caKey, err := s.depot.CA([]byte(s.caPass))

--- a/depot/signer.go
+++ b/depot/signer.go
@@ -97,7 +97,7 @@ func (s *Signer) SignCSR(m *scep.CSRReqMessage) (*x509.Certificate, error) {
 	}
 
 	if s.serverAttrs {
-		tmpl.KeyUsage |= x509.KeyUsageDataEncipherment
+		tmpl.KeyUsage |= x509.KeyUsageDataEncipherment | x509.KeyUsageKeyEncipherment
 		tmpl.ExtKeyUsage = append(tmpl.ExtKeyUsage, x509.ExtKeyUsageServerAuth)
 	}
 

--- a/depot/signer.go
+++ b/depot/signer.go
@@ -97,7 +97,7 @@ func (s *Signer) SignCSR(m *scep.CSRReqMessage) (*x509.Certificate, error) {
 	}
 
 	if s.serverAttrs {
-		tmpl |= x509.KeyUsageDataEncipherment
+		tmpl.KeyUsage |= x509.KeyUsageDataEncipherment
 		tmpl.ExtKeyUsage = append(tmpl.ExtKeyUsage, x509.ExtKeyUsageServerAuth)
 	}
 


### PR DESCRIPTION
Create a server option and CLI switch to add key usages to the certificate for server-type certificates.