### PR TITLE
Set digest algorithm to SHA256 to fix the insecure algorithm SHA1-RSA error.

### DIFF
--- a/scep/scep.go
+++ b/scep/scep.go
@@ -582,6 +582,8 @@ func NewCSRRequest(csr *x509.CertificateRequest, tmpl *PKIMessage, opts ...Optio
 		return nil, err
 	}
 
+	signedData.SetDigestAlgorithm(pkcs7.OIDDigestAlgorithmSHA256)
+	
 	// create transaction ID from public key hash
 	tID, err := newTransactionID(csr.PublicKey)
 	if err != nil {

--- a/scep/scep.go
+++ b/scep/scep.go
@@ -423,6 +423,8 @@ func (msg *PKIMessage) Fail(crtAuth *x509.Certificate, keyAuth *rsa.PrivateKey, 
 		return nil, err
 	}
 
+	sd.SetDigestAlgorithm(pkcs7.OIDDigestAlgorithmSHA256)
+	
 	// sign the attributes
 	if err := sd.AddSigner(crtAuth, keyAuth, config); err != nil {
 		return nil, err
@@ -502,6 +504,9 @@ func (msg *PKIMessage) Success(crtAuth *x509.Certificate, keyAuth *rsa.PrivateKe
 	if err != nil {
 		return nil, err
 	}
+	
+	signedData.SetDigestAlgorithm(pkcs7.OIDDigestAlgorithmSHA256)
+	
 	// add the certificate into the signed data type
 	// this cert must be added before the signedData because the recipient will expect it
 	// as the first certificate in the array


### PR DESCRIPTION
Getting the following error after upgrading to go 1.18:
PKIOperation for PKCSReq (19): http request failed with status 500 Internal Server Error, msg: x509: cannot verify signature: insecure algorithm SHA1-RSA (temporarily override with GODEBUG=x509sha1=1)

Fixed the issue by setting the digest algorithm to SHA256.