### PR TITLE
Increase Signer grace from 600ns to 10 minutes

### DIFF
--- a/depot/signer.go
+++ b/depot/signer.go
@@ -75,7 +75,7 @@ func (s *Signer) SignCSR(m *scep.CSRReqMessage) (*x509.Certificate, error) {
 	tmpl := &x509.Certificate{
 		SerialNumber: serial,
 		Subject:      m.CSR.Subject,
-		NotBefore:    time.Now().Add(-600).UTC(),
+		NotBefore:    time.Now().Add(time.Second * -600).UTC(),
 		NotAfter:     time.Now().AddDate(0, 0, s.validityDays).UTC(),
 		SubjectKeyId: id,
 		KeyUsage:     x509.KeyUsageDigitalSignature,


### PR DESCRIPTION
Got an error in some enrollment cases, where the device's time was slightly off of the server's time (about 10 seconds)
It seems like when issuing a certificate, it was intentionally subtracting time in the `NotBefore` field for to allow these minor discrepancies.
The problem is that it was adding -600 **nanoseconds** which is not nearly enough for such cases, and I think was a mistake as it seems the intention was to add -600 **seconds**
Hope I'm right :)