### PR TITLE
Allow caller to set handler path on scepserver.MakeHTTPHandler

### DIFF
--- a/depot/bolt/depot.go
+++ b/depot/bolt/depot.go
@@ -14,7 +14,7 @@ import (
 	"github.com/boltdb/bolt"
 )
 
-// Depot implements a SCEP certifiacte store using boltdb.
+// Depot implements a SCEP certificate store using boltdb.
 // https://github.com/boltdb/bolt
 type Depot struct {
 	*bolt.DB

--- a/server/transport.go
+++ b/server/transport.go
@@ -24,13 +24,13 @@ func MakeHTTPHandler(e *Endpoints, svc Service, logger kitlog.Logger) http.Handl
 	}
 
 	r := mux.NewRouter()
-	r.Methods("GET").Path("/scep").Handler(kithttp.NewServer(
+	r.Methods("GET").Handler(kithttp.NewServer(
 		e.GetEndpoint,
 		decodeSCEPRequest,
 		encodeSCEPResponse,
 		opts...,
 	))
-	r.Methods("POST").Path("/scep").Handler(kithttp.NewServer(
+	r.Methods("POST").Handler(kithttp.NewServer(
 		e.PostEndpoint,
 		decodeSCEPRequest,
 		encodeSCEPResponse,


### PR DESCRIPTION
Hi folks.

This change allows callers of `scepserver.MakeHTTPHandler` to choose/set the path for the SCEP service (other than `/scep`).