### PR TITLE
Build binary file with latest sourcecode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,16 @@
-FROM alpine:3
+FROM golang:alpine3.16 as builder
 
-COPY ./scepclient-linux-amd64 /usr/bin/scepclient
-COPY ./scepserver-linux-amd64 /usr/bin/scepserver
+WORKDIR /scep
+
+COPY . /scep/
+
+RUN apk add --update make && make
+
+
+FROM alpine:3.16
+
+COPY --from=builder /scep/scepclient-linux-amd64 /usr/bin/scepclient
+COPY --from=builder /scep/scepserver-linux-amd64 /usr/bin/scepserver
 
 EXPOSE 8080
 


### PR DESCRIPTION
Since the binaries in the repo are older than the source code. Use this Dockerfile to compile the binary with the latest code and apply to the container