### PR TITLE
Allowing specifying signing algorithm for depot signer

### DIFF
--- a/depot/signer.go
+++ b/depot/signer.go
@@ -89,7 +89,7 @@ func (s *Signer) SignCSR(m *scep.CSRReqMessage) (*x509.Certificate, error) {
 		return nil, err
 	}
 
-	signatureAlgo := m.CSR.SignatureAlgorithm
+	var signatureAlgo x509.SignatureAlgorithm
 	if s.signatureAlgo != 0 {
 		signatureAlgo = s.signatureAlgo
 	}

--- a/depot/signer.go
+++ b/depot/signer.go
@@ -21,7 +21,6 @@ type Signer struct {
 	signatureAlgo    x509.SignatureAlgorithm
 }
 
-
 // Option customizes Signer
 type Option func(*Signer)
 
@@ -31,7 +30,7 @@ func NewSigner(depot Depot, opts ...Option) *Signer {
 		depot:            depot,
 		allowRenewalDays: 14,
 		validityDays:     365,
-		signatureAlgo:	  0,
+		signatureAlgo:    0,
 	}
 	for _, opt := range opts {
 		opt(s)

--- a/server/service_bolt_test.go
+++ b/server/service_bolt_test.go
@@ -131,6 +131,12 @@ func TestCaCert(t *testing.T) {
 			t.Error("no established chain between issued cert and CA")
 		}
 
+		if csr.SignatureAlgorithm != respCert.SignatureAlgorithm {
+			t.Fatal(fmt.Errorf("cert signature algo %s different from csr signature algo %s",
+				csr.SignatureAlgorithm.String(),
+				respCert.SignatureAlgorithm.String()))
+		}
+
 		// verify unique certificate serials
 		for _, ser := range serCollector {
 			if respCert.SerialNumber.Cmp(ser) == 0 {


### PR DESCRIPTION
[x] Summary
While creating the x509 template for signing certificates, the depot signer specifies the signing algorithm as picked from the x509 CSR. This assumption is incorrect because the CA key type will not always match the requestor's key type.  In addition, the signing algorithm in the CSR is for generally for the verifier to know what algorithm is to be used to verify the CSR signature. While the algorithm to be used to sign the actual certificate is more of a CA/Signer property.

This PR retains the existing behavior but allows overrides for consumers of the depot library.

[x] Test
```
[scep]$ make test
go test -cover ./...
?   	github.com/micromdm/scep/v2/challenge/bolt	[no test files]
?   	github.com/micromdm/scep/v2/client	[no test files]
ok  	github.com/micromdm/scep/v2/challenge	(cached)	coverage: 85.7% of statements
?   	github.com/micromdm/scep/v2/cmd/scepclient	[no test files]
?   	github.com/micromdm/scep/v2/cmd/scepserver	[no test files]
ok  	github.com/micromdm/scep/v2/cryptoutil	(cached)	coverage: 80.0% of statements
ok  	github.com/micromdm/scep/v2/cryptoutil/x509util	(cached)	coverage: 44.9% of statements
?   	github.com/micromdm/scep/v2/csrverifier	[no test files]
?   	github.com/micromdm/scep/v2/depot	[no test files]
?   	github.com/micromdm/scep/v2/csrverifier/executable	[no test files]
ok  	github.com/micromdm/scep/v2/depot/bolt	(cached)	coverage: 55.8% of statements
?   	github.com/micromdm/scep/v2/depot/file	[no test files]
ok  	github.com/micromdm/scep/v2/scep	(cached)	coverage: 60.2% of statements
ok  	github.com/micromdm/scep/v2/server	0.207s	coverage: 44.9% of statements
```