### PR TITLE
Fix Docker build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 VERSION=$(shell git describe --tags --always --dirty)
 LDFLAGS=-ldflags "-X main.version=$(VERSION)"
 OSARCH=$(shell go env GOHOSTOS)-$(shell go env GOHOSTARCH)
+CGO_ENABLED=1
 
 SCEPCLIENT=\
 	scepclient-linux-amd64 \
@@ -23,12 +24,13 @@ my: scepclient-$(OSARCH) scepserver-$(OSARCH)
 win: scepclient-$(OSARCH).exe scepserver-$(OSARCH).exe
 
 docker: scepclient-linux-amd64 scepserver-linux-amd64
+  CGO_ENABLED=0
 
 $(SCEPCLIENT):
-	GOOS=$(word 2,$(subst -, ,$@)) GOARCH=$(word 3,$(subst -, ,$(subst .exe,,$@))) go build $(LDFLAGS) -o $@ ./cmd/scepclient
+	CGO_ENABLED=$(CGO_ENABLED) GOOS=$(word 2,$(subst -, ,$@)) GOARCH=$(word 3,$(subst -, ,$(subst .exe,,$@))) go build $(LDFLAGS) -o $@ ./cmd/scepclient
 
 $(SCEPSERVER):
-	GOOS=$(word 2,$(subst -, ,$@)) GOARCH=$(word 3,$(subst -, ,$(subst .exe,,$@))) go build $(LDFLAGS) -o $@ ./cmd/scepserver
+	CGO_ENABLED=$(CGO_ENABLED) GOOS=$(word 2,$(subst -, ,$@)) GOARCH=$(word 3,$(subst -, ,$(subst .exe,,$@))) go build $(LDFLAGS) -o $@ ./cmd/scepserver
 
 %-$(VERSION).zip: %.exe
 	rm -f $@


### PR DESCRIPTION
Currently the docker build creates an incompatible binary for alpine, when compiling on non musl operating systems causing a runtime error when starting the container